### PR TITLE
Implemented frequency stats for habits

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ lein repl;
 # (ns user) to switch to the user namespace.
 possbily-something-else => (ns user)
 user => (start)
+# If you have changed code within /habby/api since starting the repl, use `refresh` to start using the new code
+# without needing to restart the repl
+user => (refresh)
 ```
 
 Great, you're good to develop now!

--- a/api/dev-resources/user.clj
+++ b/api/dev-resources/user.clj
@@ -4,7 +4,9 @@
             [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.pedestal :as lp]
             [io.pedestal.http :as http]
-            [clojure.walk :as walk])
+            [clojure.walk :as walk]
+            [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.test :refer [run-tests]])
   (:import (clojure.lang IPersistentMap)))
 
 (def schema (s/load-schema))

--- a/api/project.clj
+++ b/api/project.clj
@@ -9,7 +9,8 @@
                  [io.aviso/logging "0.2.0"]
                  [com.novemberain/monger "3.1.0"]
                  [slingshot "0.12.2"]
-                 [clj-time "0.14.2"]]
+                 [clj-time "0.14.2"]
+                 [proto-repl "0.3.1"]]
   :main ^:skip-aot api.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -56,7 +56,18 @@
                                        :habit_id {:type (non-null ID)}
                                        :date {:type (non-null :date)
                                               :resolve :query/date-to-y-m-d-format}
-                                       :amount {:type (non-null Int)}}}}
+                                       :amount {:type (non-null Int)}}}
+
+           :habit_frequency_stats {:description "Statistics for how the user has performed with this habit."
+                                   :fields {:habit_id {:type (non-null ID)}
+                                            :total_fragments {:type Int}
+                                            :successful_fragments {:type Int}
+                                            :total_done {:type Int}
+                                            :current_fragment_streak {:type Int}
+                                            :best_fragment_streak {:type Int}
+                                            :current_fragment_total {:type Int}
+                                            :current_fragment_goal {:type Int}
+                                            :current_fragment_days_left {:type Int}}}}
 
  :queries {:get_habits {:type (non-null (list (non-null :habit)))
                         :description "Get all habits."
@@ -65,7 +76,13 @@
            :get_habit_data {:type (non-null (list (non-null :habit_day_record)))
                             :description "Get all the habit data that matches the request specifications."
                             :args {:after_date {:type :date_data}, :for_habit {:type ID}}
-                            :resolve :query/get-habit-data}}
+                            :resolve :query/get-habit-data}
+
+           :get_frequency_stats {:type (non-null (list (non-null :habit_frequency_stats)))
+                                 :description "Get a success percentage for each habit requested."
+                                 :args {:habit_ids {:type (list (non-null ID))}
+                                        :current_client_date {:type (non-null :date_data)}}
+                                 :resolve :query/get-frequency-stats}}
 
  :input-objects {:date_data {:description "A year/month/day."
                               :fields {:year {:type (non-null Int)}

--- a/api/src/api/db.clj
+++ b/api/src/api/db.clj
@@ -4,7 +4,8 @@
             [monger.collection :as mc]
             [monger.operators :refer :all]
             [monger.joda-time]
-            [api.util :refer [date-to-y-m-d-map, date-from-y-m-d-map]])
+            [api.util :refer :all]
+            [clj-time.core :as t])
   (:import org.bson.types.ObjectId org.joda.time.DateTimeZone))
 
 (DateTimeZone/setDefault DateTimeZone/UTC)
@@ -16,12 +17,12 @@
 
 (defonce connection (mg/connect))
 
-(defonce db (mg/get-db connection "habby"))
+(defonce habby_db (mg/get-db connection "habby"))
 
 (defn add-habit
   "Add a habit to the database and returns that habit including the ID.
   Will create an ID if the habit passed doesn't have an ID. Will set `suspended` to false."
-  [habit]
+  [{:keys [db habit] :or {db habby_db}}]
   (let [ final_habit (as-> habit habit
                           (if (contains? habit :_id) habit (assoc habit :_id (ObjectId.)))
                           (assoc habit :suspended false))]
@@ -29,34 +30,126 @@
 
 (defn delete-habit
   "Deletes a habit from the database, returns true if the habit was deleted."
-  [habit_id]
+  [{:keys [db habit_id] :or {db habby_db}}]
   (= 1 (.getN (mc/remove-by-id db (:habits collection-names) (ObjectId. habit_id)))))
 
 (defn set-suspend-habit
   "Set the `suspended` for a habit, returns true if the update was performed on the habit."
-  [habit_id suspended]
+  [{:keys [db habit_id suspended] :or {db habby_db}}]
   (= 1 (.getN (mc/update db (:habits collection-names) {:_id (ObjectId. habit_id)} {$set {:suspended suspended}}))))
 
 (defn get-habits
   "Retrieves all habits sync from the database as clojure maps."
-  []
+  [{:keys [db] :or {db habby_db}}]
   (mc/find-maps db (:habits collection-names)))
 
 (defn get-habit-data
   "Gets habit data from the db, optionally after a specific date or for a specific habit."
-  [after_date for_habit]
+  [{:keys [db after_date for_habit] :or {db habby_db}}]
   (as-> {} find-query-filter
         (if (nil? for_habit) find-query-filter (assoc find-query-filter :habit_id (ObjectId. for_habit)))
         (if (nil? after_date) find-query-filter (assoc find-query-filter :date {$gte (date-from-y-m-d-map after_date)}))
-        (mc/find-maps db (:habit_data collection-names) find-query-filter )))
+        (mc/find-maps db (:habit_data collection-names) find-query-filter)))
 
 (defn set-habit-data
   "Set the `amount` for a habit on a specfic day."
-  [habit_id amount date-time]
-  (mc/find-and-modify
-             db
-             (:habit_data collection-names)
-             {:date date-time, :habit_id (ObjectId. habit_id)}
-             {$set {:amount amount}
-              $setOnInsert {:date date-time, :habit_id (ObjectId. habit_id), :_id (ObjectId.)}}
-             {:upsert true, :return-new true}))
+  [{:keys [db habit_id amount date-time] :or {db habby_db}}]
+  (mc/find-and-modify db
+                      (:habit_data collection-names)
+                      {:date date-time, :habit_id (ObjectId. habit_id)}
+                      {$set {:amount amount}
+                       $setOnInsert {:date date-time, :habit_id (ObjectId. habit_id), :_id (ObjectId.)}}
+                      {:upsert true, :return-new true}))
+
+(defn get-frequency-stats
+  "Input: a list of habit IDs
+  Output: A list of habit_frequency_stats (one for each habit ID provided)"
+  [{:keys [db habit_ids current_client_date] :or {db habby_db, current_client_date (t/today-at 0 0)}}]
+  (map (fn [habit]
+         (let [sorted_habit_data (sort-by :date (get-habit-data {:db db :for_habit (str (:_id habit))}))]
+           (if (empty? sorted_habit_data)
+             ; User has not started habit yet
+             {:habit_id (str (:_id habit))
+              :total_fragments 0
+              :successful_fragments 0
+              :total_done 0
+              :current_fragment_streak 0
+              :best_fragment_streak 0
+              :current_fragment_total 0
+              :current_fragment_goal 0
+              :current_fragment_days_left 0}
+             (let [habit_type (:type_name habit)
+                   freq (if (= habit_type "good_habit") (:target_frequency habit) (:threshold_frequency habit))
+                   freq_type (:type_name freq)
+                   compare_fn (if (= habit_type "good_habit") >= <=)]
+                  (loop
+                    [total_fragments 0
+                     successful_fragments 0
+                     total_done 0
+                     current_fragment_streak 0
+                     best_fragment_streak 0
+                     remaining_habit_data sorted_habit_data
+                     fragment_start_date (if (= freq_type "total_week_frequency")
+                                           ; Start calendar week fragment on the Monday before the first habit record
+                                           (t/minus (:date (first sorted_habit_data))
+                                                    (t/days (- (t/day-of-week (:date (first sorted_habit_data)))
+                                                               1)))
+                                           ; Start fragment at the date of the first habit record
+                                           (:date (first sorted_habit_data)))]
+                    (let
+                      [fragment_end_date (condp = freq_type
+                                           "specific_day_of_week_frequency" fragment_start_date
+                                           "total_week_frequency" (t/plus fragment_start_date
+                                                                          (t/days 6))
+                                           "every_x_days_frequency" (t/plus fragment_start_date
+                                                                            (t/days (dec (:days freq)))))
+                       fragment_goal (condp = freq_type
+                                       "specific_day_of_week_frequency" ((condp = (t/day-of-week fragment_start_date)
+                                                                           1 :monday 2 :tuesday 3 :wednesday 4 :thursday
+                                                                           5 :friday 6 :saturday 7 :sunday)
+                                                                         freq)
+                                       "total_week_frequency" (:week freq)
+                                       "every_x_days_frequency" (:times freq))
+                       habit_data_partition (group-by #(if (or (are-datetimes-same-date (:date %) fragment_start_date)
+                                                               (are-datetimes-same-date (:date %) fragment_end_date)
+                                                               (and (t/after? (:date %) fragment_start_date)
+                                                                    (t/before? (:date %) fragment_end_date)))
+                                                         :fragment_data
+                                                         :other_data)
+                                                      remaining_habit_data)
+                       total_done_during_fragment (reduce #(+ %1 (:amount %2)) 0 (:fragment_data habit_data_partition))]
+                      (if (or (t/after? fragment_end_date current_client_date)
+                              (t/equal? fragment_end_date current_client_date))
+                        ; We've reached the current fragment the user is on, return now.
+                        ; We don't include the current fragment in success stats but we do increase total_done.
+                        {:habit_id (str (:_id habit))
+                         :total_fragments total_fragments
+                         :successful_fragments successful_fragments
+                         :total_done (+ total_done total_done_during_fragment)
+                         :current_fragment_streak current_fragment_streak
+                         :best_fragment_streak best_fragment_streak
+                         :current_fragment_total total_done_during_fragment
+                         :current_fragment_goal fragment_goal
+                         :current_fragment_days_left (inc (t/in-days (t/interval current_client_date fragment_end_date)))}
+                        ; Track the current fragment
+                        (let [fragment_is_successful (compare_fn total_done_during_fragment fragment_goal)
+                              new_current_fragment_streak (if fragment_is_successful (inc current_fragment_streak) 0)]
+                          (recur (inc total_fragments)
+                                 (if fragment_is_successful (inc successful_fragments) successful_fragments)
+                                 (+ total_done total_done_during_fragment)
+                                 new_current_fragment_streak
+                                 (if (> new_current_fragment_streak best_fragment_streak)
+                                   new_current_fragment_streak
+                                   best_fragment_streak)
+                                 (:other_data habit_data_partition)
+                                 (t/plus fragment_start_date
+                                         (t/days (condp = freq_type
+                                                   "specific_day_of_week_frequency" 1
+                                                   "total_week_frequency" 7
+                                                   "every_x_days_frequency" (:days freq)))))))))))))
+       (if (nil? habit_ids)
+         (get-habits {:db db})
+         (map (fn [habit_id] (mc/find-map-by-id db
+                                                (:habits collection-names)
+                                                (ObjectId. habit_id)))
+              habit_ids))))

--- a/api/src/api/schema.clj
+++ b/api/src/api/schema.clj
@@ -71,33 +71,37 @@
 (defn resolve-get-habits
   "@refer `db/get-habits`."
   [context args value]
-  (map tag-type (db/get-habits)))
+  (map tag-type (db/get-habits args)))
 
 (defn resolve-mutation-add-habit
   "@refer `db/add-habit`."
-  [context {:keys [create_habit_data] } value]
-  (tag-type (db/add-habit (unnest-tagged-unions-on-input-object create_habit_data))))
+  [context {:keys [create_habit_data] :as all} value]
+  (tag-type (db/add-habit (assoc all :habit (unnest-tagged-unions-on-input-object create_habit_data)))))
 
 (defn resolve-mutation-set-habit-data
   "@refer `db/set-habit-data`."
-  [context {:keys [habit_id amount date]} value]
-  (let [date-time (date-from-y-m-d-map date)]
-    (db/set-habit-data habit_id amount date-time)))
+  [context {:keys [habit_id amount date] :as all} value]
+  (db/set-habit-data (assoc (dissoc all :date) :date-time (date-from-y-m-d-map date))))
 
 (defn resolve-get-habit-data
   "@refer `db/get-habit-data`."
-  [context {:keys [after_date for_habit]} value]
-  (db/get-habit-data after_date for_habit))
+  [context {:keys [after_date for_habit] :as all} value]
+  (db/get-habit-data all))
 
 (defn resolve-mutation-delete-habit
   "@refer `db/delete-habit`."
-  [context {:keys [habit_id]} value]
-  (db/delete-habit habit_id))
+  [context {:keys [habit_id] :as all} value]
+  (db/delete-habit all))
 
 (defn resolve-mutation-set-suspend-habit
   "@refer `db/set-suspend-habit`."
-  [context {:keys [habit_id, suspended]} value]
-  (db/set-suspend-habit habit_id suspended))
+  [context {:keys [habit_id suspended] :as all} value]
+  (db/set-suspend-habit all))
+
+(defn resolve-query-get-frequency-stats
+  "@refer `db/get-frequency-stats`."
+  [context {:keys [habit_ids current_client_date] :as all} value]
+  (map tag-type (db/get-frequency-stats (assoc all :current_client_date (date-from-y-m-d-map current_client_date)))))
 
 (defn resolver-map
   []
@@ -109,7 +113,8 @@
    :query/get-habit-data (create-async-resolver resolve-get-habit-data)
    :query/date-to-y-m-d-format (create-date-to-y-m-d-resolver :date)
    :query/resolve-mutation-delete-habit (create-async-resolver resolve-mutation-delete-habit)
-   :query/resolve-mutation-set-suspend-habit (create-async-resolver resolve-mutation-set-suspend-habit)})
+   :query/resolve-mutation-set-suspend-habit (create-async-resolver resolve-mutation-set-suspend-habit)
+   :query/get-frequency-stats (create-async-resolver resolve-query-get-frequency-stats)})
 
 (defn load-schema
   []

--- a/api/src/api/util.clj
+++ b/api/src/api/util.clj
@@ -13,6 +13,14 @@
   [{:keys [year month day]}]
   (t/date-time year month day))
 
+(defn are-datetimes-same-date
+  "Input: two clj-time.core/date-time objects
+  Output: true iff they are on the same date (i.e. ignore time)"
+  [dt1 dt2]
+  (and (= (t/year dt1) (t/year dt2))
+       (= (t/month dt1) (t/month dt2))
+       (= (t/day dt1) (t/day dt2))))
+
 (defn value-map
   "Maps a function on the values of a map, returns a map with the updated values."
   [m f]

--- a/api/test/api/db_test.clj
+++ b/api/test/api/db_test.clj
@@ -1,0 +1,206 @@
+(ns api.db-test
+  (:require [clojure.test :refer :all]
+            [clojure.data :refer [diff]]
+            [api.db :refer :all]
+            [monger.core :as mg]
+            [monger.db :as mdb]
+            [clj-time.core :as t]))
+
+; Useful variables
+(def test_conn (mg/connect))
+(def test_db (mg/get-db test_conn "test_db"))
+(def default_habit {:name "test habit" :description "test description" :unit_name_singular "test unit"
+                    :unit_name_plural "test units" :time_of_day :ANYTIME})
+(def today (t/today-at 0 0))
+(def default_frequency_stats {:total_fragments 0, :successful_fragments 0, :total_done 0,
+                              :current_fragment_streak 0, :best_fragment_streak 0,
+                              :current_fragment_total 0, :current_fragment_goal 0, :current_fragment_days_left 0})
+
+(defn add-habit-to-test-db
+  "Add a habit to the test database"
+  [habit]
+  (add-habit {:db test_db :habit habit}))
+
+(defn compare_clojure_habit_with_db_habit
+  "Returns true iff all fields of `clojure_habit` have the same value in `db_habit`.
+  Checks Keyword values in `clojure_habit` against the Keyword-ed version of the value in `db_habit`
+  since Keywords are converted to Strings by Monger.
+  Note that this function doesn't care if `db_habit` has a field that `clojure_habit` doesn't have."
+  [clojure_habit db_habit]
+  (every? (fn [key]
+           (let [clj_val (key clojure_habit)
+                 db_val (key db_habit)]
+             (if (= (type clj_val) clojure.lang.Keyword)
+               (= clj_val (keyword db_val))
+               (= clj_val db_val))))
+          (keys clojure_habit)))
+
+(defn supermap?
+  "Returns true iff all fields of `map2` have the same value in `map1`.
+  I.e., `map1` is a supermap of `map2`. Patent pending."
+  [map1 map2]
+  (nil? (first (diff map2 map1))))
+
+(deftest add-habit-test
+  (testing "No habits"
+    (is (= 0 (count (get-habits {:db test_db})))))
+  (let [habit_1 (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "total_week_frequency"
+                                          :week 6})
+        _ (add-habit-to-test-db habit_1)
+        all_habits (get-habits {:db test_db})]
+    (testing "One habit"
+      (is (= 1 (count all_habits)) "There should be one habit in the db")
+      (is (some #(compare_clojure_habit_with_db_habit habit_1 %) all_habits) "Habit 1 not added properly")
+      (is (every? #(= false (:suspended %)) all_habits) ":suspended field not set to false")
+      (is (every? #(not (nil? (:_id %))) all_habits) ":_id field not set"))
+    (let [habit_2 (assoc default_habit
+                         :type_name "bad_habit"
+                         :threshold_frequency {:type_name "every_x_days_frequency"
+                                               :days 4
+                                               :times 3})
+          _ (add-habit-to-test-db habit_2)
+          all_habits (get-habits {:db test_db})]
+      (testing "Two habits"
+        (is (= 2 (count all_habits)) "There should be two habits in the db")
+        (is (some #(compare_clojure_habit_with_db_habit habit_1 %) all_habits) "Habit 1 not added properly")
+        (is (some #(compare_clojure_habit_with_db_habit habit_2 %) all_habits) "Habit 2 not added properly")
+        (is (every? #(= false (:suspended %)) all_habits) ":suspended field not set to false")
+        (is (every? #(not (nil? (:_id %))) all_habits) ":_id field not set")))))
+
+(deftest get-frequency-stats-test
+  (testing "No habits added yet"
+    (is (= 0 (count (get-habits {:db test_db})))))
+  (testing "Good habit, specific day of week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "specific_day_of_week_frequency"
+                                          :monday 2 :tuesday 2 :wednesday 2 :thursday 2
+                                          :friday 2 :saturday 2 :sunday 2})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with no habit data"
+        (is (= 1 (count (get-habits {:db test_db}))) "There should only be one habit so far")
+        (is (= [(assoc default_frequency_stats :habit_id habit_id)]
+               (get-frequency-stats {:db test_db :habit_ids [habit_id]})))
+        (is (= [(assoc default_frequency_stats :habit_id habit_id)]
+               (get-frequency-stats {:db test_db})) "`habit_ids` should be an optional param"))
+      (testing "with a successful habit record yesterday"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 4
+                                 :date-time (t/minus today (t/days 1))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (= stats [{:habit_id habit_id
+                         :total_fragments 1 :successful_fragments 1 :total_done 4
+                         :current_fragment_streak 1 :best_fragment_streak 1
+                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+        (testing "and a failure habit record the day before"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 1
+                                   :date-time (t/minus today (t/days 2))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (= stats [{:habit_id habit_id
+                           :total_fragments 2 :successful_fragments 1 :total_done 5
+                           :current_fragment_streak 1 :best_fragment_streak 1
+                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+          (testing "and at 11pm today the user did 3 units"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 3 :date-time (t/plus today (t/hours 23))})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (= stats [{:habit_id habit_id
+                             :total_fragments 2 :successful_fragments 1 :total_done 8
+                             :current_fragment_streak 1 :best_fragment_streak 1
+                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 1}]))))))))
+  (testing "Good habit, total week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "total_week_frequency"
+                                          :week 5})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with last week as a failure"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 3
+                                 ; 7 days ago was in the previous week, which has now ended
+                                 :date-time (t/minus today (t/days 7))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 ; this week hasn't ended so we only track last week
+                                 :total_fragments 1 :successful_fragments 0 :total_done 3
+                                 :current_fragment_streak 0 :best_fragment_streak 0
+                                 :current_fragment_total 0 :current_fragment_goal 5}])))
+        (testing "and the week before as a success"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 5
+                                   :date-time (t/minus today (t/days 14))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 2 :successful_fragments 1 :total_done 8
+                                   :current_fragment_streak 0 :best_fragment_streak 1
+                                   :current_fragment_total 0 :current_fragment_goal 5}])))
+          (testing "and today the user did 6 units"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 6 :date-time today})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (supermap? stats [{:habit_id habit_id
+                                     :total_fragments 2 :successful_fragments 1 :total_done 14
+                                     :current_fragment_streak 0 :best_fragment_streak 1
+                                     :current_fragment_total 6 :current_fragment_goal 5}]))))))))
+  (testing "Good habit, every x days frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "every_x_days_frequency"
+                                          :times 3 :days 5})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with the last fragment as a success"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 200
+                                 :date-time (t/minus today (t/days 5))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 :total_fragments 1 :successful_fragments 1 :total_done 200
+                                 :current_fragment_streak 1 :best_fragment_streak 1
+                                 :current_fragment_total 0 :current_fragment_goal 3}])))
+        (testing "and three fragments ago as a failure"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 2
+                                   :date-time (t/minus today (t/days 15))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 3 :successful_fragments 1 :total_done 202
+                                   :current_fragment_streak 1 :best_fragment_streak 1
+                                   :current_fragment_total 0 :current_fragment_goal 3}])))))))
+  (testing "Bad habit, total week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "bad_habit"
+                       :threshold_frequency {:type_name "total_week_frequency"
+                                             :week 20})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with last week as a success"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 0
+                                 :date-time (t/minus today (t/days 7))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 :total_fragments 1 :successful_fragments 1 :total_done 0
+                                 :current_fragment_streak 1 :best_fragment_streak 1
+                                 :current_fragment_total 0 :current_fragment_goal 20}])))
+        (testing "and the week before that as a success"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 20
+                                   :date-time (t/minus today (t/days 14))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 2 :successful_fragments 2 :total_done 20
+                                   :current_fragment_streak 2 :best_fragment_streak 2
+                                   :current_fragment_total 0 :current_fragment_goal 20}])))
+          (testing "and three weeks ago as a failure"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 21
+                                     :date-time (t/minus today (t/days 21))})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (supermap? stats [{:habit_id habit_id
+                                     :total_fragments 3 :successful_fragments 2 :total_done 41
+                                     :current_fragment_streak 2 :best_fragment_streak 2
+                                     :current_fragment_total 0 :current_fragment_goal 20}])))))))))
+
+(defn drop-test-db-fixture
+  "Drop test database before and after each test"
+  [f]
+  (mdb/drop-db test_db)
+  (f)
+  (mdb/drop-db test_db))
+
+(use-fixtures :each drop-test-db-fixture)

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -1,0 +1,83 @@
+module HabitUtil exposing (..)
+
+{-| Module for useful Habit operations
+-}
+
+import Models.Habit as Habit
+import Models.FrequencyStats as FrequencyStats
+
+
+isHabitCurrentFragmentSuccessful : Habit.Habit -> FrequencyStats.FrequencyStats -> Bool
+isHabitCurrentFragmentSuccessful habit frequencyStats =
+    case habit of
+        Habit.GoodHabit _ ->
+            frequencyStats.currentFragmentTotal >= frequencyStats.currentFragmentGoal
+
+        Habit.BadHabit _ ->
+            frequencyStats.currentFragmentTotal <= frequencyStats.currentFragmentGoal
+
+
+findFrequencyStatsForHabit : Habit.Habit -> List FrequencyStats.FrequencyStats -> Result String FrequencyStats.FrequencyStats
+findFrequencyStatsForHabit habit frequencyStats =
+    let
+        habitId =
+            (.id (Habit.getCommonFields habit))
+
+        filteredFrequencyStatsByHabitId =
+            List.filter (\stats -> stats.habitId == habitId) frequencyStats
+    in
+        case filteredFrequencyStatsByHabitId of
+            [] ->
+                Err ("No frequency stats found for habit " ++ habitId)
+
+            [ s ] ->
+                Ok s
+
+            s1 :: s2 :: _ ->
+                Err ("More than one frequency stats found for habit " ++ habitId ++ ", something fishy is going on")
+
+
+{-| Returns the habits sorted first by whether the current fragment goal has already been achieved
+(unfinished habits come first), and then by the number of days remaining in the current time fragment
+(more urgent habit goals come first).
+-}
+sortHabitsByCurrentFragment : List FrequencyStats.FrequencyStats -> List Habit.Habit -> List Habit.Habit
+sortHabitsByCurrentFragment frequencyStatsList habits =
+    let
+        compareHabits : Habit.Habit -> Habit.Habit -> Order
+        compareHabits habitOne habitTwo =
+            let
+                habitOneFrequencyStats =
+                    findFrequencyStatsForHabit habitOne frequencyStatsList
+
+                habitTwoFrequencyStats =
+                    findFrequencyStatsForHabit habitTwo frequencyStatsList
+            in
+                case ( habitOneFrequencyStats, habitTwoFrequencyStats ) of
+                    ( Err _, Err _ ) ->
+                        EQ
+
+                    ( Err _, Ok _ ) ->
+                        GT
+
+                    ( Ok _, Err _ ) ->
+                        LT
+
+                    ( Ok statsOne, Ok statsTwo ) ->
+                        let
+                            isHabitOneAlreadySuccessful =
+                                isHabitCurrentFragmentSuccessful habitOne statsOne
+
+                            isHabitTwoAlreadySuccessful =
+                                isHabitCurrentFragmentSuccessful habitTwo statsTwo
+                        in
+                            if isHabitOneAlreadySuccessful == isHabitTwoAlreadySuccessful then
+                                compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+                            else if isHabitOneAlreadySuccessful then
+                                -- We know they are different so if `isHabitOneAlreadySuccessful` is true
+                                -- then `isHabitTwoAlreadySuccessful` must be false
+                                GT
+                            else
+                                LT
+    in
+        List.sortWith compareHabits habits

--- a/web-client/src/Init.elm
+++ b/web-client/src/Init.elm
@@ -14,17 +14,26 @@ import RemoteData
 
 init : Flags -> Navigation.Location -> ( Model, Cmd Msg )
 init { apiBaseUrl, currentTime } location =
-    ( { ymd = currentTime |> Date.fromTime |> YmdDate.fromDate
-      , apiBaseUrl = apiBaseUrl
-      , editingTodayHabitAmount = Dict.empty
-      , editingHistoryHabitAmount = Dict.empty
-      , allHabitData = RemoteData.Loading
-      , allHabits = RemoteData.Loading
-      , addHabit = Habit.initAddHabitData
-      , openTodayViewer = True
-      , openHistoryViewer = False
-      , historyViewerDateInput = ""
-      , historyViewerSelectedDate = Nothing
-      }
-    , Api.queryHabitsAndHabitData apiBaseUrl OnGetHabitsAndHabitDataFailure OnGetHabitsAndHabitDataSuccess
-    )
+    let
+        ymd =
+            currentTime |> Date.fromTime |> YmdDate.fromDate
+    in
+        ( { ymd = ymd
+          , apiBaseUrl = apiBaseUrl
+          , editingTodayHabitAmount = Dict.empty
+          , editingHistoryHabitAmount = Dict.empty
+          , allHabitData = RemoteData.Loading
+          , allHabits = RemoteData.Loading
+          , allFrequencyStats = RemoteData.Loading
+          , addHabit = Habit.initAddHabitData
+          , openTodayViewer = True
+          , openHistoryViewer = False
+          , historyViewerDateInput = ""
+          , historyViewerSelectedDate = Nothing
+          }
+        , Api.queryHabitsAndHabitDataAndFrequencyStats
+            ymd
+            apiBaseUrl
+            OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+        )

--- a/web-client/src/Model.elm
+++ b/web-client/src/Model.elm
@@ -4,6 +4,7 @@ import Dict
 import Models.ApiError as ApiError
 import Models.Habit as Habit
 import Models.HabitData as HabitData
+import Models.FrequencyStats as FrequencyStats
 import Models.YmdDate as YmdDate
 import RemoteData
 
@@ -15,6 +16,7 @@ type alias Model =
     , editingHistoryHabitAmount : Dict.Dict String (Dict.Dict String Int)
     , allHabits : RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     , allHabitData : RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    , allFrequencyStats : RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     , addHabit :
         { openView : Bool
         , kind : Habit.HabitKind

--- a/web-client/src/Models/FrequencyStats.elm
+++ b/web-client/src/Models/FrequencyStats.elm
@@ -1,0 +1,31 @@
+module Models.FrequencyStats exposing (..)
+
+import Json.Decode as Decode exposing (null)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
+
+
+type alias FrequencyStats =
+    { habitId : String
+    , totalFragments : Int
+    , successfulFragments : Int
+    , totalDone : Int
+    , currentFragmentStreak : Int
+    , bestFragmentStreak : Int
+    , currentFragmentTotal : Int
+    , currentFragmentGoal : Int
+    , currentFragmentDaysLeft : Int
+    }
+
+
+decodeFrequencyStats : Decode.Decoder FrequencyStats
+decodeFrequencyStats =
+    decode FrequencyStats
+        |> required "habit_id" Decode.string
+        |> required "total_fragments" Decode.int
+        |> required "successful_fragments" Decode.int
+        |> required "total_done" Decode.int
+        |> required "current_fragment_streak" Decode.int
+        |> required "best_fragment_streak" Decode.int
+        |> required "current_fragment_total" Decode.int
+        |> required "current_fragment_goal" Decode.int
+        |> required "current_fragment_days_left" Decode.int

--- a/web-client/src/Models/Habit.elm
+++ b/web-client/src/Models/Habit.elm
@@ -170,7 +170,7 @@ splitHabits habits =
                 )
                 habits
     in
-    ( goodHabits, badHabits )
+        ( goodHabits, badHabits )
 
 
 {-| Retrieve fields that exist on both good and bad habits.
@@ -291,22 +291,22 @@ extractCreateHabit addHabitInputData =
                         _ ->
                             Nothing
     in
-    case addHabitInputData.kind of
-        GoodHabitKind ->
-            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                    Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
+        case addHabitInputData.kind of
+            GoodHabitKind ->
+                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                        Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
 
-                _ ->
-                    Nothing
+                    _ ->
+                        Nothing
 
-        BadHabitKind ->
-            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                    Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
+            BadHabitKind ->
+                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                        Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
 
-                _ ->
-                    Nothing
+                    _ ->
+                        Nothing
 
 
 decodeHabit : Decode.Decoder Habit
@@ -333,19 +333,19 @@ decodeHabit =
                 |> required "unit_name_plural" Decode.string
                 |> required "threshold_frequency" decodeFrequency
     in
-    Decode.at [ "__typename" ] Decode.string
-        |> Decode.andThen
-            (\typeName ->
-                case typeName of
-                    "good_habit" ->
-                        decodeGoodHabitRecord |> Decode.map GoodHabit
+        Decode.at [ "__typename" ] Decode.string
+            |> Decode.andThen
+                (\typeName ->
+                    case typeName of
+                        "good_habit" ->
+                            decodeGoodHabitRecord |> Decode.map GoodHabit
 
-                    "bad_habit" ->
-                        decodeBadHabitRecord |> Decode.map BadHabit
+                        "bad_habit" ->
+                            decodeBadHabitRecord |> Decode.map BadHabit
 
-                    _ ->
-                        Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
-            )
+                        _ ->
+                            Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
+                )
 
 
 decodeFrequency : Decode.Decoder Frequency
@@ -369,22 +369,22 @@ decodeFrequency =
                 |> optional "saturday" Decode.int 0
                 |> optional "sunday" Decode.int 0
     in
-    Decode.at [ "__typename" ] Decode.string
-        |> Decode.andThen
-            (\typeName ->
-                case typeName of
-                    "specific_day_of_week_frequency" ->
-                        decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
+        Decode.at [ "__typename" ] Decode.string
+            |> Decode.andThen
+                (\typeName ->
+                    case typeName of
+                        "specific_day_of_week_frequency" ->
+                            decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
 
-                    "total_week_frequency" ->
-                        decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
+                        "total_week_frequency" ->
+                            decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
 
-                    "every_x_days_frequency" ->
-                        decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
+                        "every_x_days_frequency" ->
+                            decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
 
-                    _ ->
-                        Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
-            )
+                        _ ->
+                            Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
+                )
 
 
 decodeHabitTime : Decode.Decoder HabitTime
@@ -404,4 +404,4 @@ decodeHabitTime =
                 _ ->
                     Decode.fail <| str ++ " is not a valid habit time."
     in
-    Decode.string |> Decode.andThen fromStringDecoder
+        Decode.string |> Decode.andThen fromStringDecoder

--- a/web-client/src/Msg.elm
+++ b/web-client/src/Msg.elm
@@ -13,8 +13,8 @@ type Msg
     = NoOp
     | OnLocationChange Navigation.Location
     | TickMinute Time.Time
-    | OnGetHabitsAndHabitDataFailure ApiError
-    | OnGetHabitsAndHabitDataSuccess Api.HabitsAndHabitData
+    | OnGetHabitsAndHabitDataAndFrequencyStatsFailure ApiError
+    | OnGetHabitsAndHabitDataAndFrequencyStatsSuccess Api.HabitsAndHabitDataAndFrequencyStats
     | OnOpenAddHabit
     | OnCancelAddHabit
     | OnSelectAddHabitKind Habit.HabitKind

--- a/web-client/src/Styles/global.scss
+++ b/web-client/src/Styles/global.scss
@@ -279,6 +279,35 @@
 
             .habit-name {
                 font-weight: 600;
+                width: 150px;
+                float: left;
+            }
+
+            .frequency-stats {
+                margin-left: 10px;
+                text-overflow: ellipsis;
+                font-weight: 200;
+                font-size: 12px;
+                color: blue;
+                text-align: right;
+                float: right;
+                .frequency-statistic{
+                  width: 130px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                }
+                .frequency-stats-title {
+                  font-weight: 600;
+                  text-decoration: underline;
+                }
+                .current-fragment-success {
+                  color: green;
+                }
+                .current-fragment-failure {
+                  color: #802200;  // dark red text
+                  font-weight: 200;
+                }
             }
 
             .habit-amount-complete {
@@ -286,7 +315,7 @@
                 position: absolute;
                 bottom: 7px;
                 border: none;
-                width: 200px;
+                width: 160px;
 
                 input  {
                     box-sizing: border-box;

--- a/web-client/src/Update.elm
+++ b/web-client/src/Update.elm
@@ -18,251 +18,257 @@ update msg model =
         updateAddHabit updater =
             { model | addHabit = updater model.addHabit }
     in
-    case msg of
-        NoOp ->
-            ( model, Cmd.none )
+        case msg of
+            NoOp ->
+                ( model, Cmd.none )
 
-        OnLocationChange location ->
-            -- TODO
-            ( model, Cmd.none )
+            OnLocationChange location ->
+                -- TODO
+                ( model, Cmd.none )
 
-        TickMinute time ->
-            ( { model | ymd = time |> Date.fromTime |> YmdDate.fromDate }, Cmd.none )
+            TickMinute time ->
+                ( { model | ymd = time |> Date.fromTime |> YmdDate.fromDate }, Cmd.none )
 
-        OnGetHabitsAndHabitDataFailure apiError ->
-            ( { model
-                | allHabits = RemoteData.Failure apiError
-                , allHabitData = RemoteData.Failure apiError
-              }
-            , Cmd.none
-            )
+            OnGetHabitsAndHabitDataAndFrequencyStatsFailure apiError ->
+                ( { model
+                    | allHabits = RemoteData.Failure apiError
+                    , allHabitData = RemoteData.Failure apiError
+                    , allFrequencyStats = RemoteData.Failure apiError
+                  }
+                , Cmd.none
+                )
 
-        OnGetHabitsAndHabitDataSuccess { habits, habitData } ->
-            ( { model
-                | allHabits = RemoteData.Success habits
-                , allHabitData = RemoteData.Success habitData
-              }
-            , Cmd.none
-            )
+            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess { habits, habitData, frequencyStatsList } ->
+                ( { model
+                    | allHabits = RemoteData.Success habits
+                    , allHabitData = RemoteData.Success habitData
+                    , allFrequencyStats = RemoteData.Success frequencyStatsList
+                  }
+                , Cmd.none
+                )
 
-        OnOpenAddHabit ->
-            ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
+            OnOpenAddHabit ->
+                ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
 
-        OnCancelAddHabit ->
-            ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
+            OnCancelAddHabit ->
+                ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
 
-        OnSelectAddHabitKind habitKind ->
-            ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
+            OnSelectAddHabitKind habitKind ->
+                ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
 
-        OnAddHabitNameInput habitName ->
-            ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
+            OnAddHabitNameInput habitName ->
+                ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
 
-        OnAddHabitDescriptionInput habitDescription ->
-            ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
+            OnAddHabitDescriptionInput habitDescription ->
+                ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
 
-        OnSelectAddGoodHabitTime goodHabitTime ->
-            ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
+            OnSelectAddGoodHabitTime goodHabitTime ->
+                ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
 
-        OnAddHabitUnitNameSingularInput unitNameSingular ->
-            ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
+            OnAddHabitUnitNameSingularInput unitNameSingular ->
+                ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
 
-        OnAddHabitUnitNamePluralInput unitNamePlural ->
-            ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
+            OnAddHabitUnitNamePluralInput unitNamePlural ->
+                ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
 
-        OnAddHabitSelectFrequencyKind frequencyKind ->
-            ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
+            OnAddHabitSelectFrequencyKind frequencyKind ->
+                ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
 
-        OnAddHabitTimesPerWeekInput timesPerWeek ->
-            ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
-            , Cmd.none
-            )
+            OnAddHabitTimesPerWeekInput timesPerWeek ->
+                ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayMondayInput mondayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayMondayInput mondayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayThursdayInput thursdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayThursdayInput thursdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayFridayInput fridayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayFridayInput fridayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDaySundayInput sundayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDaySundayInput sundayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitTimesInput times ->
-            ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
-            , Cmd.none
-            )
+            OnAddHabitTimesInput times ->
+                ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
+                , Cmd.none
+                )
 
-        OnAddHabitDaysInput days ->
-            ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
-            , Cmd.none
-            )
+            OnAddHabitDaysInput days ->
+                ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
+                , Cmd.none
+                )
 
-        AddHabit createHabitData ->
-            ( model
-            , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
-            )
+            AddHabit createHabitData ->
+                ( model
+                , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
+                )
 
-        OnAddHabitFailure apiError ->
-            -- TODO
-            ( model, Cmd.none )
+            OnAddHabitFailure apiError ->
+                -- TODO
+                ( model, Cmd.none )
 
-        OnAddHabitSuccess habit ->
-            ( { model
-                | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
-                , addHabit = Habit.initAddHabitData
-              }
-            , Cmd.none
-            )
+            OnAddHabitSuccess habit ->
+                ( { model
+                    | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
+                    , addHabit = Habit.initAddHabitData
+                  }
+                , Cmd.none
+                )
 
-        OnHabitDataInput habitID newVal ->
-            let
-                newEditingTodayHabitAmount amount =
-                    model.editingTodayHabitAmount
-                        |> Dict.update habitID (always <| amount)
-            in
-            if String.isEmpty newVal then
-                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
-            else
-                case String.toInt newVal of
-                    Result.Err _ ->
+            OnHabitDataInput habitID newVal ->
+                let
+                    newEditingTodayHabitAmount amount =
+                        model.editingTodayHabitAmount
+                            |> Dict.update habitID (always <| amount)
+                in
+                    if String.isEmpty newVal then
+                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
+                    else
+                        case String.toInt newVal of
+                            Result.Err _ ->
+                                ( model, Cmd.none )
+
+                            Result.Ok newInt ->
+                                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
+
+            SetHabitData ymd habitId newVal ->
+                case newVal of
+                    Nothing ->
                         ( model, Cmd.none )
 
-                    Result.Ok newInt ->
-                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
+                    Just newVal ->
+                        ( model
+                        , Api.mutationSetHabitData
+                            ymd
+                            habitId
+                            newVal
+                            model.apiBaseUrl
+                            OnSetHabitDataFailure
+                            OnSetHabitDataSuccess
+                        )
 
-        SetHabitData ymd habitId newVal ->
-            case newVal of
-                Nothing ->
-                    ( model, Cmd.none )
+            OnSetHabitDataFailure apiError ->
+                -- TODO
+                ( model, Cmd.none )
 
-                Just newVal ->
-                    ( model
-                    , Api.mutationSetHabitData
-                        ymd
-                        habitId
-                        newVal
-                        model.apiBaseUrl
-                        OnSetHabitDataFailure
-                        OnSetHabitDataSuccess
+            OnSetHabitDataSuccess updatedHabitDatum ->
+                ( { model
+                    | allHabitData =
+                        RemoteData.map
+                            (\allHabitData ->
+                                Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
+                            )
+                            model.allHabitData
+                    , editingTodayHabitAmount =
+                        Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
+                    , editingHistoryHabitAmount =
+                        Dict.update
+                            (YmdDate.toSimpleString updatedHabitDatum.date)
+                            (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
+                            model.editingHistoryHabitAmount
+                  }
+                , Api.queryHabitsAndHabitDataAndFrequencyStats
+                    model.ymd
+                    model.apiBaseUrl
+                    OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+                    OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+                )
+
+            OnToggleHistoryViewer ->
+                ( { model | openHistoryViewer = not model.openHistoryViewer }
+                , Cmd.none
+                )
+
+            OnToggleTodayViewer ->
+                ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
+
+            OnHistoryViewerDateInput newDateInput ->
+                ( { model
+                    | historyViewerDateInput =
+                        newDateInput
+                            |> String.filter
+                                (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
+                  }
+                , Cmd.none
+                )
+
+            OnHistoryViewerSelectYesterday ->
+                let
+                    yesterday =
+                        YmdDate.addDays -1 model.ymd
+                in
+                    ( { model | historyViewerSelectedDate = Just yesterday }, Cmd.none )
+
+            OnHistoryViewerSelectBeforeYesterday ->
+                let
+                    beforeYesterday =
+                        YmdDate.addDays -2 model.ymd
+                in
+                    ( { model | historyViewerSelectedDate = Just beforeYesterday }
+                    , Cmd.none
                     )
 
-        OnSetHabitDataFailure apiError ->
-            -- TODO
-            ( model, Cmd.none )
-
-        OnSetHabitDataSuccess updatedHabitDatum ->
-            ( { model
-                | allHabitData =
-                    RemoteData.map
-                        (\allHabitData ->
-                            Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
+            OnHistoryViewerSelectDateInput ->
+                model.historyViewerDateInput
+                    |> YmdDate.fromSimpleString
+                    ||> (\ymd ->
+                            ( { model | historyViewerSelectedDate = Just ymd }
+                            , Cmd.none
+                            )
                         )
-                        model.allHabitData
-                , editingTodayHabitAmount =
-                    Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
-                , editingHistoryHabitAmount =
-                    Dict.update
-                        (YmdDate.toSimpleString updatedHabitDatum.date)
-                        (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
+                    ?> ( model, Cmd.none )
+
+            OnHistoryViewerChangeDate ->
+                ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
+
+            OnHistoryViewerHabitDataInput forDate habitId newInput ->
+                let
+                    editingHabitDataDict =
                         model.editingHistoryHabitAmount
-              }
-            , Cmd.none
-            )
+                            |> Dict.get (YmdDate.toSimpleString forDate)
+                            ?> Dict.empty
 
-        OnToggleHistoryViewer ->
-            ( { model | openHistoryViewer = not model.openHistoryViewer }
-            , Cmd.none
-            )
+                    newAmount =
+                        extractInt newInput (Dict.get habitId editingHabitDataDict)
 
-        OnToggleTodayViewer ->
-            ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
-
-        OnHistoryViewerDateInput newDateInput ->
-            ( { model
-                | historyViewerDateInput =
-                    newDateInput
-                        |> String.filter
-                            (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
-              }
-            , Cmd.none
-            )
-
-        OnHistoryViewerSelectYesterday ->
-            let
-                yesterday =
-                    YmdDate.addDays -1 model.ymd
-            in
-            ( { model | historyViewerSelectedDate = Just yesterday }, Cmd.none )
-
-        OnHistoryViewerSelectBeforeYesterday ->
-            let
-                beforeYesterday =
-                    YmdDate.addDays -2 model.ymd
-            in
-            ( { model | historyViewerSelectedDate = Just beforeYesterday }
-            , Cmd.none
-            )
-
-        OnHistoryViewerSelectDateInput ->
-            model.historyViewerDateInput
-                |> YmdDate.fromSimpleString
-                ||> (\ymd ->
-                        ( { model | historyViewerSelectedDate = Just ymd }
-                        , Cmd.none
-                        )
+                    updatedEditingHabitDataDict =
+                        editingHabitDataDict |> Dict.update habitId (always newAmount)
+                in
+                    ( { model
+                        | editingHistoryHabitAmount =
+                            model.editingHistoryHabitAmount
+                                |> Dict.update
+                                    (YmdDate.toSimpleString forDate)
+                                    (always <| Just updatedEditingHabitDataDict)
+                      }
+                    , Cmd.none
                     )
-                ?> ( model, Cmd.none )
-
-        OnHistoryViewerChangeDate ->
-            ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
-
-        OnHistoryViewerHabitDataInput forDate habitId newInput ->
-            let
-                editingHabitDataDict =
-                    model.editingHistoryHabitAmount
-                        |> Dict.get (YmdDate.toSimpleString forDate)
-                        ?> Dict.empty
-
-                newAmount =
-                    extractInt newInput (Dict.get habitId editingHabitDataDict)
-
-                updatedEditingHabitDataDict =
-                    editingHabitDataDict |> Dict.update habitId (always newAmount)
-            in
-            ( { model
-                | editingHistoryHabitAmount =
-                    model.editingHistoryHabitAmount
-                        |> Dict.update
-                            (YmdDate.toSimpleString forDate)
-                            (always <| Just updatedEditingHabitDataDict)
-              }
-            , Cmd.none
-            )
 
 
 extractInt : String -> Maybe Int -> Maybe Int

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -3,6 +3,7 @@ module View exposing (..)
 import DefaultServices.Infix exposing (..)
 import DefaultServices.Util as Util
 import Dict
+import HabitUtil
 import Html exposing (Html, button, div, hr, i, input, span, text, textarea)
 import Html.Attributes exposing (class, classList, placeholder, value)
 import Html.Events exposing (onClick, onInput)
@@ -10,6 +11,7 @@ import Keyboard.Extra as KK
 import Maybe.Extra as Maybe
 import Model exposing (Model)
 import Models.ApiError as ApiError
+import Models.FrequencyStats as FrequencyStats
 import Models.Habit as Habit
 import Models.HabitData as HabitData
 import Models.YmdDate as YmdDate
@@ -25,6 +27,7 @@ view model =
             model.ymd
             model.allHabits
             model.allHabitData
+            model.allFrequencyStats
             model.addHabit
             model.editingTodayHabitAmount
             model.openTodayViewer
@@ -34,6 +37,7 @@ view model =
             model.historyViewerSelectedDate
             model.allHabits
             model.allHabitData
+            model.allFrequencyStats
             model.editingHistoryHabitAmount
         ]
 
@@ -42,243 +46,269 @@ renderTodayPanel :
     YmdDate.YmdDate
     -> RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     -> RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    -> RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     -> Habit.AddHabitInputData
     -> Dict.Dict String Int
     -> Bool
     -> Html Msg
-renderTodayPanel ymd rdHabits rdHabitData addHabit editingHabitDataDict openView =
+renderTodayPanel ymd rdHabits rdHabitData rdFrequencyStatsList addHabit editingHabitDataDict openView =
     let
         createHabitData =
             Habit.extractCreateHabit addHabit
     in
-    div
-        [ class "today-panel" ]
-        [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Todays Progress" ]
-        , dropdownIcon openView NoOp
-        , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
-        , case ( rdHabits, rdHabitData ) of
-            ( RemoteData.Success habits, RemoteData.Success habitData ) ->
-                let
-                    ( goodHabits, badHabits ) =
-                        Habit.splitHabits habits
+        div
+            [ class "today-panel" ]
+            [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Today's Progress" ]
+            , dropdownIcon openView NoOp
+            , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
+            , case ( rdHabits, rdHabitData ) of
+                ( RemoteData.Success habits, RemoteData.Success habitData ) ->
+                    let
+                        ( goodHabits, badHabits ) =
+                            Habit.splitHabits habits
 
-                    renderHabit habit =
-                        renderHabitBox ymd habitData editingHabitDataDict OnHabitDataInput SetHabitData habit
-                in
-                div [ classList [ ( "display-none", not openView ) ] ]
-                    [ div
-                        [ class "habit-list good-habits" ]
-                        (List.map renderHabit goodHabits)
-                    , div
-                        [ class "habit-list bad-habits" ]
-                        (List.map renderHabit badHabits)
+                        ( sortedGoodHabits, sortedBadHabits ) =
+                            case rdFrequencyStatsList of
+                                RemoteData.Success frequencyStatsList ->
+                                    ( HabitUtil.sortHabitsByCurrentFragment frequencyStatsList goodHabits
+                                    , HabitUtil.sortHabitsByCurrentFragment frequencyStatsList badHabits
+                                    )
+
+                                _ ->
+                                    ( goodHabits, badHabits )
+
+                        renderHabit habit =
+                            renderHabitBox
+                                (case rdFrequencyStatsList of
+                                    RemoteData.Success frequencyStatsList ->
+                                        HabitUtil.findFrequencyStatsForHabit
+                                            habit
+                                            frequencyStatsList
+
+                                    _ ->
+                                        Err "Frequency stats not available for any habits"
+                                )
+                                ymd
+                                habitData
+                                editingHabitDataDict
+                                OnHabitDataInput
+                                SetHabitData
+                                habit
+                    in
+                        div [ classList [ ( "display-none", not openView ) ] ]
+                            [ div
+                                [ class "habit-list good-habits" ]
+                                (List.map renderHabit sortedGoodHabits)
+                            , div
+                                [ class "habit-list bad-habits" ]
+                                (List.map renderHabit sortedBadHabits)
+                            , button
+                                [ class "add-habit"
+                                , onClick <|
+                                    if addHabit.openView then
+                                        OnCancelAddHabit
+                                    else
+                                        OnOpenAddHabit
+                                ]
+                                [ text <|
+                                    if addHabit.openView then
+                                        "Cancel"
+                                    else
+                                        "Add Habit"
+                                ]
+                            ]
+
+                ( RemoteData.Failure apiError, _ ) ->
+                    text "Failure..."
+
+                ( _, RemoteData.Failure apiError ) ->
+                    text "Failure..."
+
+                _ ->
+                    text "Loading..."
+            , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
+            , div
+                [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
+                [ div
+                    [ class "add-habit-input-form-habit-tag-name" ]
+                    [ button
+                        [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
+                        , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
+                        ]
+                        [ text "Good Habit" ]
                     , button
-                        [ class "add-habit"
-                        , onClick <|
-                            if addHabit.openView then
-                                OnCancelAddHabit
-                            else
-                                OnOpenAddHabit
+                        [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
+                        , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
                         ]
-                        [ text <|
-                            if addHabit.openView then
-                                "Cancel"
-                            else
-                                "Add Habit"
+                        [ text "Bad Habit" ]
+                    ]
+                , div
+                    [ class "add-habit-input-form-name-and-description" ]
+                    [ input
+                        [ class "add-habit-input-form-name"
+                        , placeholder "Name..."
+                        , onInput OnAddHabitNameInput
+                        , value addHabit.name
+                        ]
+                        []
+                    , textarea
+                        [ class "add-habit-input-form-description"
+                        , placeholder "Short description..."
+                        , onInput OnAddHabitDescriptionInput
+                        , value addHabit.description
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-time-of-day", True )
+                        , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
                         ]
                     ]
-
-            ( RemoteData.Failure apiError, _ ) ->
-                text "Failure..."
-
-            ( _, RemoteData.Failure apiError ) ->
-                text "Failure..."
-
-            _ ->
-                text "Loading..."
-        , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
-        , div
-            [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
-            [ div
-                [ class "add-habit-input-form-habit-tag-name" ]
-                [ button
-                    [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
-                    , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
-                    ]
-                    [ text "Good Habit" ]
-                , button
-                    [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
-                    , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
-                    ]
-                    [ text "Bad Habit" ]
-                ]
-            , div
-                [ class "add-habit-input-form-name-and-description" ]
-                [ input
-                    [ class "add-habit-input-form-name"
-                    , placeholder "Name..."
-                    , onInput OnAddHabitNameInput
-                    , value addHabit.name
-                    ]
-                    []
-                , textarea
-                    [ class "add-habit-input-form-description"
-                    , placeholder "Short description..."
-                    , onInput OnAddHabitDescriptionInput
-                    , value addHabit.description
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-time-of-day", True )
-                    , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
-                    ]
-                ]
-                [ button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
-                    ]
-                    [ text "ANYTIME" ]
-                , button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Morning
-                    ]
-                    [ text "MORNING" ]
-                , button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Evening
-                    ]
-                    [ text "EVENING" ]
-                ]
-            , div
-                [ class "add-habit-input-form-unit-name" ]
-                [ input
-                    [ class "habit-unit-name-singular"
-                    , placeholder "Unit name singular..."
-                    , onInput OnAddHabitUnitNameSingularInput
-                    , value addHabit.unitNameSingular
-                    ]
-                    []
-                , input
-                    [ class "habit-unit-name-plural"
-                    , placeholder "Unit name plural..."
-                    , onInput OnAddHabitUnitNamePluralInput
-                    , value addHabit.unitNamePlural
-                    ]
-                    []
-                ]
-            , div
-                [ class "add-habit-input-form-frequency-tag-name" ]
-                [ button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
-                    ]
-                    [ text "X Per Week" ]
-                , button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
-                    ]
-                    [ text "Specific Days of Week" ]
-                , button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
-                    ]
-                    [ text "Y Per X Days" ]
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-x-times-per-week", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "X"
-                    , onInput OnAddHabitTimesPerWeekInput
-                    , value (addHabit.timesPerWeek ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-specific-days-of-week", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "Monday"
-                    , onInput OnAddHabitSpecificDayMondayInput
-                    , value (addHabit.mondayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Tuesday"
-                    , onInput OnAddHabitSpecificDayTuesdayInput
-                    , value (addHabit.tuesdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Wednesday"
-                    , onInput OnAddHabitSpecificDayWednesdayInput
-                    , value (addHabit.wednesdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Thursday"
-                    , onInput OnAddHabitSpecificDayThursdayInput
-                    , value (addHabit.thursdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Friday"
-                    , onInput OnAddHabitSpecificDayFridayInput
-                    , value (addHabit.fridayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Saturday"
-                    , onInput OnAddHabitSpecificDaySaturdayInput
-                    , value (addHabit.saturdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Sunday"
-                    , onInput OnAddHabitSpecificDaySundayInput
-                    , value (addHabit.sundayTimes ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-x-times-per-y-days", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "Times"
-                    , onInput OnAddHabitTimesInput
-                    , value (addHabit.times ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Days"
-                    , onInput OnAddHabitDaysInput
-                    , value (addHabit.days ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , case createHabitData of
-                Nothing ->
-                    Util.hiddenDiv
-
-                Just createHabitData ->
-                    button
-                        [ class "add-new-habit"
-                        , onClick <| AddHabit createHabitData
+                    [ button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
                         ]
-                        [ text "Create Habit" ]
+                        [ text "ANYTIME" ]
+                    , button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Morning
+                        ]
+                        [ text "MORNING" ]
+                    , button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Evening
+                        ]
+                        [ text "EVENING" ]
+                    ]
+                , div
+                    [ class "add-habit-input-form-unit-name" ]
+                    [ input
+                        [ class "habit-unit-name-singular"
+                        , placeholder "Unit name singular..."
+                        , onInput OnAddHabitUnitNameSingularInput
+                        , value addHabit.unitNameSingular
+                        ]
+                        []
+                    , input
+                        [ class "habit-unit-name-plural"
+                        , placeholder "Unit name plural..."
+                        , onInput OnAddHabitUnitNamePluralInput
+                        , value addHabit.unitNamePlural
+                        ]
+                        []
+                    ]
+                , div
+                    [ class "add-habit-input-form-frequency-tag-name" ]
+                    [ button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
+                        ]
+                        [ text "X Per Week" ]
+                    , button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
+                        ]
+                        [ text "Specific Days of Week" ]
+                    , button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
+                        ]
+                        [ text "Y Per X Days" ]
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-x-times-per-week", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "X"
+                        , onInput OnAddHabitTimesPerWeekInput
+                        , value (addHabit.timesPerWeek ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-specific-days-of-week", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "Monday"
+                        , onInput OnAddHabitSpecificDayMondayInput
+                        , value (addHabit.mondayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Tuesday"
+                        , onInput OnAddHabitSpecificDayTuesdayInput
+                        , value (addHabit.tuesdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Wednesday"
+                        , onInput OnAddHabitSpecificDayWednesdayInput
+                        , value (addHabit.wednesdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Thursday"
+                        , onInput OnAddHabitSpecificDayThursdayInput
+                        , value (addHabit.thursdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Friday"
+                        , onInput OnAddHabitSpecificDayFridayInput
+                        , value (addHabit.fridayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Saturday"
+                        , onInput OnAddHabitSpecificDaySaturdayInput
+                        , value (addHabit.saturdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Sunday"
+                        , onInput OnAddHabitSpecificDaySundayInput
+                        , value (addHabit.sundayTimes ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-x-times-per-y-days", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "Times"
+                        , onInput OnAddHabitTimesInput
+                        , value (addHabit.times ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Days"
+                        , onInput OnAddHabitDaysInput
+                        , value (addHabit.days ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , case createHabitData of
+                    Nothing ->
+                        Util.hiddenDiv
+
+                    Just createHabitData ->
+                        button
+                            [ class "add-new-habit"
+                            , onClick <| AddHabit createHabitData
+                            ]
+                            [ text "Create Habit" ]
+                ]
             ]
-        ]
 
 
 renderHistoryViewerPanel :
@@ -287,9 +317,10 @@ renderHistoryViewerPanel :
     -> Maybe YmdDate.YmdDate
     -> RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     -> RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    -> RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     -> Dict.Dict String (Dict.Dict String Int)
     -> Html Msg
-renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData editingHabitDataDictDict =
+renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData rdFrequencyStatsList editingHabitDataDictDict =
     case ( rdHabits, rdHabitData ) of
         ( RemoteData.Success habits, RemoteData.Success habitData ) ->
             div
@@ -334,6 +365,7 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData ed
 
                                 renderHabit habit =
                                     renderHabitBox
+                                        (Err "Ignore frequency stats for historical data")
                                         selectedDate
                                         habitData
                                         editingHabitDataDict
@@ -341,13 +373,13 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData ed
                                         SetHabitData
                                         habit
                             in
-                            div
-                                []
-                                [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
-                                , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
-                                , div [ class "habit-list good-habits" ] <| List.map renderHabit goodHabits
-                                , div [ class "habit-list bad-habits" ] <| List.map renderHabit badHabits
-                                ]
+                                div
+                                    []
+                                    [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
+                                    , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
+                                    , div [ class "habit-list good-habits" ] <| List.map renderHabit goodHabits
+                                    , div [ class "habit-list bad-habits" ] <| List.map renderHabit badHabits
+                                    ]
                 ]
 
         ( RemoteData.Failure apiError, _ ) ->
@@ -381,14 +413,15 @@ update the habit data.
 
 -}
 renderHabitBox :
-    YmdDate.YmdDate
+    Result String FrequencyStats.FrequencyStats
+    -> YmdDate.YmdDate
     -> List HabitData.HabitData
     -> Dict.Dict String Int
     -> (String -> String -> Msg)
     -> (YmdDate.YmdDate -> String -> Maybe Int -> Msg)
     -> Habit.Habit
     -> Html Msg
-renderHabitBox ymd habitData editingHabitDataDict onHabitDataInput setHabitData habit =
+renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput setHabitData habit =
     let
         habitRecord =
             Habit.getCommonFields habit
@@ -408,39 +441,83 @@ renderHabitBox ymd habitData editingHabitDataDict onHabitDataInput setHabitData 
         editingHabitData =
             Dict.get habitRecord.id editingHabitDataDict
     in
-    div
-        [ class "habit" ]
-        [ div [ class "habit-name" ] [ text habitRecord.name ]
-        , div
-            [ classList
-                [ ( "habit-amount-complete", True )
-                , ( "editing", Maybe.isJust <| editingHabitData )
+        div
+            [ class "habit" ]
+            [ div [ class "habit-name" ] [ text habitRecord.name ]
+            , (case habitStats of
+                Err _ ->
+                    div [ class "frequency-stats" ] [ text "N/A" ]
+
+                Ok stats ->
+                    div [ class "frequency-stats" ]
+                        [ div
+                            [ classList
+                                [ ( "current-fragment-success", HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
+                                , ( "current-fragment-failure", not <| HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
+                                , ( "frequency-statistic", True )
+                                ]
+                            ]
+                            [ text <|
+                                (toString stats.currentFragmentTotal)
+                                    ++ " out of "
+                                    ++ (toString stats.currentFragmentGoal)
+                                    ++ " "
+                                    ++ habitRecord.unitNamePlural
+                            ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <|
+                                "Days left: "
+                                    ++ (toString stats.currentFragmentDaysLeft)
+                            ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <|
+                                (toString <|
+                                    round <|
+                                        (toFloat stats.successfulFragments)
+                                            * 100
+                                            / (toFloat stats.totalFragments)
+                                )
+                                    ++ "%"
+                            ]
+                        , div
+                            [ class "frequency-statistic" ]
+                            [ text <| "Streak: " ++ (toString stats.currentFragmentStreak) ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <| "Best streak: " ++ (toString stats.bestFragmentStreak) ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <| "Total done: " ++ (toString stats.totalDone) ]
+                        ]
+              )
+            , div
+                [ classList
+                    [ ( "habit-amount-complete", True )
+                    , ( "editing", Maybe.isJust <| editingHabitData )
+                    ]
                 ]
-            ]
-            [ input
-                [ placeholder <|
-                    toString habitDatum
-                        ++ " "
-                        ++ (if habitDatum == 1 then
-                                habitRecord.unitNameSingular
+                [ input
+                    [ placeholder <|
+                        toString habitDatum
+                            ++ " "
+                            ++ (if habitDatum == 1 then
+                                    habitRecord.unitNameSingular
+                                else
+                                    habitRecord.unitNamePlural
+                               )
+                    , onInput <| onHabitDataInput habitRecord.id
+                    , Util.onKeydown
+                        (\key ->
+                            if key == KK.Enter then
+                                Just <| setHabitData ymd habitRecord.id editingHabitData
                             else
-                                habitRecord.unitNamePlural
-                           )
-                , onInput <| onHabitDataInput habitRecord.id
-                , Util.onKeydown
-                    (\key ->
-                        if key == KK.Enter then
-                            Just <| setHabitData ymd habitRecord.id editingHabitData
-                        else
-                            Nothing
-                    )
-                , value (editingHabitData ||> toString ?> "")
+                                Nothing
+                        )
+                    , value (editingHabitData ||> toString ?> "")
+                    ]
+                    []
+                , i
+                    [ classList [ ( "material-icons", True ) ]
+                    , onClick <| setHabitData ymd habitRecord.id editingHabitData
+                    ]
+                    [ text "check_box" ]
                 ]
-                []
-            , i
-                [ classList [ ( "material-icons", True ) ]
-                , onClick <| setHabitData ymd habitRecord.id editingHabitData
-                ]
-                [ text "check_box" ]
             ]
-        ]


### PR DESCRIPTION
  - Create GraphQL query get_frequency_stats that returns performance statistics for the requested habits (default: all habits)
  - Show frequency stats on page
  - Automatically update frequency stats when new habt data is entered
  - Sort habits by completion of current fragment goal, and by days left in current fragment

Along the way a couple dev tools used:
  - Added proto-repl to project.clj as a dependency
  - Imported clojure.tools.namespace.repl/refresh for easier refreshing of namespaces while developing
  - Imported clojure.test/run-tests so you can always run tests from user namespace
  - Added documentation about refreshing within lein repl