### PR TITLE
Implemented frequency stats for habits

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ lein repl;
 # (ns user) to switch to the user namespace.
 possbily-something-else => (ns user)
 user => (start)
+# If you have changed code within /habby/api since starting the repl, use `refresh` to start using the new code
+# without needing to restart the repl
+user => (refresh)
 ```
 
 Great, you're good to develop now!

--- a/api/dev-resources/user.clj
+++ b/api/dev-resources/user.clj
@@ -4,7 +4,9 @@
             [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.pedestal :as lp]
             [io.pedestal.http :as http]
-            [clojure.walk :as walk])
+            [clojure.walk :as walk]
+            [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.test :refer [run-tests]])
   (:import (clojure.lang IPersistentMap)))
 
 (def schema (s/load-schema))

--- a/api/project.clj
+++ b/api/project.clj
@@ -9,7 +9,8 @@
                  [io.aviso/logging "0.2.0"]
                  [com.novemberain/monger "3.1.0"]
                  [slingshot "0.12.2"]
-                 [clj-time "0.14.2"]]
+                 [clj-time "0.14.2"]
+                 [proto-repl "0.3.1"]]
   :main ^:skip-aot api.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/api/project.clj
+++ b/api/project.clj
@@ -10,7 +10,8 @@
                  [com.novemberain/monger "3.1.0"]
                  [slingshot "0.12.2"]
                  [clj-time "0.14.2"]
-                 [proto-repl "0.3.1"]]
+                 [proto-repl "0.3.1"]
+                 [org.clojure/test.check "0.9.0"]]
   :main ^:skip-aot api.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -76,7 +76,9 @@
 
            :get_habit_data {:type (non-null (list (non-null :habit_day_record)))
                             :description "Get all the habit data that matches the request specifications."
-                            :args {:after_date {:type :date_data}, :for_habit {:type ID}}
+                            :args {:after_date {:type :date_data},
+                                   :before_date {:type :date_data},
+                                   :habit_ids {:type (list (non-null ID))}}
                             :resolve :query/get-habit-data}
 
            :get_frequency_stats {:type (non-null (list (non-null :habit_frequency_stats)))

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -60,14 +60,14 @@
 
            :habit_frequency_stats {:description "Statistics for how the user has performed with this habit."
                                    :fields {:habit_id {:type (non-null ID)}
-                                            :total_fragments {:type Int}
-                                            :successful_fragments {:type Int}
-                                            :total_done {:type Int}
-                                            :current_fragment_streak {:type Int}
-                                            :best_fragment_streak {:type Int}
-                                            :current_fragment_total {:type Int}
-                                            :current_fragment_goal {:type Int}
-                                            :current_fragment_days_left {:type Int}}}}
+                                            :total_fragments {:type (non-null Int)}
+                                            :successful_fragments {:type (non-null Int)}
+                                            :total_done {:type (non-null Int)}
+                                            :current_fragment_streak {:type (non-null Int)}
+                                            :best_fragment_streak {:type (non-null Int)}
+                                            :current_fragment_total {:type (non-null Int)}
+                                            :current_fragment_goal {:type (non-null Int)}
+                                            :current_fragment_days_left {:type (non-null Int)}}}}
 
  :queries {:get_habits {:type (non-null (list (non-null :habit)))
                         :description "Get all habits."

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -56,7 +56,18 @@
                                        :habit_id {:type (non-null ID)}
                                        :date {:type (non-null :date)
                                               :resolve :query/date-to-y-m-d-format}
-                                       :amount {:type (non-null Int)}}}}
+                                       :amount {:type (non-null Int)}}}
+
+           :habit_frequency_stats {:description "Statistics for how the user has performed with this habit."
+                                   :fields {:habit_id {:type (non-null ID)}
+                                            :total_fragments {:type Int}
+                                            :successful_fragments {:type Int}
+                                            :total_done {:type Int}
+                                            :current_fragment_streak {:type Int}
+                                            :best_fragment_streak {:type Int}
+                                            :current_fragment_total {:type Int}
+                                            :current_fragment_goal {:type Int}
+                                            :current_fragment_days_left {:type Int}}}}
 
  :queries {:get_habits {:type (non-null (list (non-null :habit)))
                         :description "Get all habits."
@@ -65,7 +76,13 @@
            :get_habit_data {:type (non-null (list (non-null :habit_day_record)))
                             :description "Get all the habit data that matches the request specifications."
                             :args {:after_date {:type :date_data}, :for_habit {:type ID}}
-                            :resolve :query/get-habit-data}}
+                            :resolve :query/get-habit-data}
+
+           :get_frequency_stats {:type (non-null (list (non-null :habit_frequency_stats)))
+                                 :description "Get a success percentage for each habit requested."
+                                 :args {:habit_ids {:type (list (non-null ID))}
+                                        :current_client_date {:type (non-null :date_data)}}
+                                 :resolve :query/get-frequency-stats}}
 
  :input-objects {:date_data {:description "A year/month/day."
                               :fields {:year {:type (non-null Int)}

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -71,6 +71,7 @@
 
  :queries {:get_habits {:type (non-null (list (non-null :habit)))
                         :description "Get all habits."
+                        :args {:habit_ids {:type (list (non-null ID))}}
                         :resolve :query/get-habits}
 
            :get_habit_data {:type (non-null (list (non-null :habit_day_record)))

--- a/api/resources/schema.edn
+++ b/api/resources/schema.edn
@@ -67,7 +67,8 @@
                                             :best_fragment_streak {:type (non-null Int)}
                                             :current_fragment_total {:type (non-null Int)}
                                             :current_fragment_goal {:type (non-null Int)}
-                                            :current_fragment_days_left {:type (non-null Int)}}}}
+                                            :current_fragment_days_left {:type (non-null Int)}
+                                            :habit_has_started {:type (non-null Boolean)}}}}
 
  :queries {:get_habits {:type (non-null (list (non-null :habit)))
                         :description "Get all habits."

--- a/api/src/api/db.clj
+++ b/api/src/api/db.clj
@@ -40,8 +40,10 @@
 
 (defn get-habits
   "Retrieves all habits sync from the database as clojure maps."
-  [{:keys [db] :or {db habby_db}}]
-  (mc/find-maps db (:habits collection-names)))
+  [{:keys [db habit_ids] :or {db habby_db}}]
+  (mc/find-maps db
+                (:habits collection-names)
+                (if (nil? habit_ids) nil {:_id {$in (map #(ObjectId. %) habit_ids)}})))
 
 (defn get-habit-data
   "Gets habit data from the db, optionally after a specific date or for a specific habit."
@@ -147,9 +149,4 @@
                                                    "specific_day_of_week_frequency" 1
                                                    "total_week_frequency" 7
                                                    "every_x_days_frequency" (:days freq)))))))))))))
-       (if (nil? habit_ids)
-         (get-habits {:db db})
-         (map (fn [habit_id] (mc/find-map-by-id db
-                                                (:habits collection-names)
-                                                (ObjectId. habit_id)))
-              habit_ids))))
+       (get-habits {:db db :habit_ids habit_ids})))

--- a/api/src/api/db.clj
+++ b/api/src/api/db.clj
@@ -80,4 +80,4 @@
         all-habit-data-until-current-date (get-habit-data {:db db,
                                                            :before_date (date-to-y-m-d-map current_client_date),
                                                            :habit_ids habit_ids})]
-    (map #(get-freq-stats-for-habit db % all-habit-data-until-current-date current_client_date) all-habits)))
+    (map #(get-freq-stats-for-habit % all-habit-data-until-current-date current_client_date) all-habits)))

--- a/api/src/api/db.clj
+++ b/api/src/api/db.clj
@@ -77,7 +77,7 @@
   [{:keys [db habit_ids current_client_date] :or {db habby_db, current_client_date (t/today-at 0 0)}}]
   (let [all-habits (get-habits {:db db,
                                 :habit_ids habit_ids}),
-        all-habit-data (get-habit-data {:db db,
-                                        :before_date (date-to-y-m-d-map current_client_date),
-                                        :habit_ids habit_ids})]
-    (map #(get-freq-stats-for-habit db % all-habit-data current_client_date) all-habits)))
+        all-habit-data-until-current-date (get-habit-data {:db db,
+                                                           :before_date (date-to-y-m-d-map current_client_date),
+                                                           :habit_ids habit_ids})]
+    (map #(get-freq-stats-for-habit db % all-habit-data-until-current-date current_client_date) all-habits)))

--- a/api/src/api/db.clj
+++ b/api/src/api/db.clj
@@ -4,7 +4,8 @@
             [monger.collection :as mc]
             [monger.operators :refer :all]
             [monger.joda-time]
-            [api.util :refer [date-to-y-m-d-map, date-from-y-m-d-map]])
+            [api.util :refer :all]
+            [clj-time.core :as t])
   (:import org.bson.types.ObjectId org.joda.time.DateTimeZone))
 
 (DateTimeZone/setDefault DateTimeZone/UTC)
@@ -16,12 +17,12 @@
 
 (defonce connection (mg/connect))
 
-(defonce db (mg/get-db connection "habby"))
+(defonce habby_db (mg/get-db connection "habby"))
 
 (defn add-habit
   "Add a habit to the database and returns that habit including the ID.
   Will create an ID if the habit passed doesn't have an ID. Will set `suspended` to false."
-  [habit]
+  [{:keys [db habit] :or {db habby_db}}]
   (let [ final_habit (as-> habit habit
                           (if (contains? habit :_id) habit (assoc habit :_id (ObjectId.)))
                           (assoc habit :suspended false))]
@@ -29,34 +30,126 @@
 
 (defn delete-habit
   "Deletes a habit from the database, returns true if the habit was deleted."
-  [habit_id]
+  [{:keys [db habit_id] :or {db habby_db}}]
   (= 1 (.getN (mc/remove-by-id db (:habits collection-names) (ObjectId. habit_id)))))
 
 (defn set-suspend-habit
   "Set the `suspended` for a habit, returns true if the update was performed on the habit."
-  [habit_id suspended]
+  [{:keys [db habit_id suspended] :or {db habby_db}}]
   (= 1 (.getN (mc/update db (:habits collection-names) {:_id (ObjectId. habit_id)} {$set {:suspended suspended}}))))
 
 (defn get-habits
   "Retrieves all habits sync from the database as clojure maps."
-  []
+  [{:keys [db] :or {db habby_db}}]
   (mc/find-maps db (:habits collection-names)))
 
 (defn get-habit-data
   "Gets habit data from the db, optionally after a specific date or for a specific habit."
-  [after_date for_habit]
+  [{:keys [db after_date for_habit] :or {db habby_db}}]
   (as-> {} find-query-filter
         (if (nil? for_habit) find-query-filter (assoc find-query-filter :habit_id (ObjectId. for_habit)))
         (if (nil? after_date) find-query-filter (assoc find-query-filter :date {$gte (date-from-y-m-d-map after_date)}))
-        (mc/find-maps db (:habit_data collection-names) find-query-filter )))
+        (mc/find-maps db (:habit_data collection-names) find-query-filter)))
 
 (defn set-habit-data
   "Set the `amount` for a habit on a specfic day."
-  [habit_id amount date-time]
-  (mc/find-and-modify
-             db
-             (:habit_data collection-names)
-             {:date date-time, :habit_id (ObjectId. habit_id)}
-             {$set {:amount amount}
-              $setOnInsert {:date date-time, :habit_id (ObjectId. habit_id), :_id (ObjectId.)}}
-             {:upsert true, :return-new true}))
+  [{:keys [db habit_id amount date-time] :or {db habby_db}}]
+  (mc/find-and-modify db
+                      (:habit_data collection-names)
+                      {:date date-time, :habit_id (ObjectId. habit_id)}
+                      {$set {:amount amount}
+                       $setOnInsert {:date date-time, :habit_id (ObjectId. habit_id), :_id (ObjectId.)}}
+                      {:upsert true, :return-new true}))
+
+(defn get-frequency-stats
+  "Input: a list of habit IDs
+  Output: A list of habit_frequency_stats (one for each habit ID provided)"
+  [{:keys [db habit_ids current_client_date] :or {db habby_db, current_client_date (t/today-at 0 0)}}]
+  (map (fn [habit]
+         (let [sorted_habit_data (sort-by :date (get-habit-data {:db db :for_habit (str (:_id habit))}))]
+           (if (empty? sorted_habit_data)
+             ; User has not started habit yet
+             {:habit_id (str (:_id habit))
+              :total_fragments 0
+              :successful_fragments 0
+              :total_done 0
+              :current_fragment_streak 0
+              :best_fragment_streak 0
+              :current_fragment_total 0
+              :current_fragment_goal 0
+              :current_fragment_days_left 0}
+             (let [habit_type (:type_name habit)
+                   freq (if (= habit_type "good_habit") (:target_frequency habit) (:threshold_frequency habit))
+                   freq_type (:type_name freq)
+                   compare_fn (if (= habit_type "good_habit") >= <=)]
+                  (loop
+                    [total_fragments 0
+                     successful_fragments 0
+                     total_done 0
+                     current_fragment_streak 0
+                     best_fragment_streak 0
+                     remaining_habit_data sorted_habit_data
+                     fragment_start_date (if (= freq_type "total_week_frequency")
+                                           ; Start calendar week fragment on the Monday before the first habit record
+                                           (t/minus (:date (first sorted_habit_data))
+                                                    (t/days (- (t/day-of-week (:date (first sorted_habit_data)))
+                                                               1)))
+                                           ; Start fragment at the date of the first habit record
+                                           (:date (first sorted_habit_data)))]
+                    (let
+                      [fragment_end_date (condp = freq_type
+                                           "specific_day_of_week_frequency" fragment_start_date
+                                           "total_week_frequency" (t/plus fragment_start_date
+                                                                          (t/days 6))
+                                           "every_x_days_frequency" (t/plus fragment_start_date
+                                                                            (t/days (dec (:days freq)))))
+                       fragment_goal (condp = freq_type
+                                       "specific_day_of_week_frequency" ((condp = (t/day-of-week fragment_start_date)
+                                                                           1 :monday 2 :tuesday 3 :wednesday 4 :thursday
+                                                                           5 :friday 6 :saturday 7 :sunday)
+                                                                         freq)
+                                       "total_week_frequency" (:week freq)
+                                       "every_x_days_frequency" (:times freq))
+                       habit_data_partition (group-by #(if (or (are-datetimes-same-date (:date %) fragment_start_date)
+                                                               (are-datetimes-same-date (:date %) fragment_end_date)
+                                                               (and (t/after? (:date %) fragment_start_date)
+                                                                    (t/before? (:date %) fragment_end_date)))
+                                                         :fragment_data
+                                                         :other_data)
+                                                      remaining_habit_data)
+                       total_done_during_fragment (reduce #(+ %1 (:amount %2)) 0 (:fragment_data habit_data_partition))]
+                      (if (or (t/after? fragment_end_date current_client_date)
+                              (t/equal? fragment_end_date current_client_date))
+                        ; We've reached the current fragment the user is on, return now.
+                        ; We don't include the current fragment in success stats but we do increase total_done.
+                        {:habit_id (str (:_id habit))
+                         :total_fragments total_fragments
+                         :successful_fragments successful_fragments
+                         :total_done (+ total_done total_done_during_fragment)
+                         :current_fragment_streak current_fragment_streak
+                         :best_fragment_streak best_fragment_streak
+                         :current_fragment_total total_done_during_fragment
+                         :current_fragment_goal fragment_goal
+                         :current_fragment_days_left (inc (t/in-days (t/interval current_client_date fragment_end_date)))}
+                        ; Track the current fragment
+                        (let [fragment_is_successful (compare_fn total_done_during_fragment fragment_goal)
+                              new_current_fragment_streak (if fragment_is_successful (inc current_fragment_streak) 0)]
+                          (recur (inc total_fragments)
+                                 (if fragment_is_successful (inc successful_fragments) successful_fragments)
+                                 (+ total_done total_done_during_fragment)
+                                 new_current_fragment_streak
+                                 (if (> new_current_fragment_streak best_fragment_streak)
+                                   new_current_fragment_streak
+                                   best_fragment_streak)
+                                 (:other_data habit_data_partition)
+                                 (t/plus fragment_start_date
+                                         (t/days (condp = freq_type
+                                                   "specific_day_of_week_frequency" 1
+                                                   "total_week_frequency" 7
+                                                   "every_x_days_frequency" (:days freq)))))))))))))
+       (if (nil? habit_ids)
+         (get-habits {:db db})
+         (map (fn [habit_id] (mc/find-map-by-id db
+                                                (:habits collection-names)
+                                                (ObjectId. habit_id)))
+              habit_ids))))

--- a/api/src/api/dt_util.clj
+++ b/api/src/api/dt_util.clj
@@ -1,0 +1,52 @@
+(ns api.dt-util
+  "A namespace for holding utilities related to `DateTime`s."
+  (:require [clj-time.core :as t]
+            [clj-time.predicates :refer [same-date?]]
+            [clj-time.periodic :refer [periodic-seq]]))
+
+(defn date-geq?
+  "Returns true iff `dt1` falls on the same date or later as `dt2`.
+  Ignores the time."
+  [dt1 dt2]
+  (or (same-date? dt1 dt2)
+      (t/after? dt1 dt2)))
+
+(defn date-leq?
+  "Returns true iff `dt1` falls on the same date or earlier as `dt2`.
+  Ignores the time."
+  [dt1 dt2]
+  (or (same-date? dt1 dt2)
+      (t/before? dt1 dt2)))
+
+(defn first-monday-before-datetime
+  "Returns the date of the first Monday before `dt`.
+  Subtracting (<day of week of `dt`> - 1) days from `dt` yields the most recent Monday.
+  Note that clj-time numbers the days of the week with 1 for Monday and 7 for Sunday."
+  [dt]
+  (t/minus dt
+           (-> dt
+               t/day-of-week
+               dec
+               t/days)))
+
+(defn get-consecutive-datetimes
+  "Returns a list of consecutive datetimes from `from-dt` to `until-dt`, inclusive."
+  [from-dt until-dt]
+  (periodic-seq from-dt
+                (t/plus until-dt (t/days 1))
+                (t/days 1)))
+
+(defn day-of-week-keyword
+  "Returns the day of week of a `DateTime`, in keyword form."
+  [dt]
+  (condp = (t/day-of-week dt)
+         1 :monday, 2 :tuesday, 3 :wednesday, 4 :thursday, 5 :friday, 6 :saturday, 7 :sunday))
+
+(defn days-spanned-between-datetimes
+  "Returns the number of days spanned from `from-dt` to `until-dt`, inclusive.
+  For instance, today until tomorrow would be 2 days spanned."
+  [from-dt until-dt]
+  (-> from-dt
+      t/with-time-at-start-of-day  ; Bring `from-dt` to start of day so that times don't interfere
+      (t/interval until-dt)
+      t/in-days))

--- a/api/src/api/dt_util.clj
+++ b/api/src/api/dt_util.clj
@@ -30,11 +30,15 @@
                t/days)))
 
 (defn get-consecutive-datetimes
-  "Returns a list of consecutive datetimes from `from-dt` to `until-dt`, inclusive."
+  "Returns a list of consecutive datetimes from `from-dt` to `until-dt`, inclusive.
+  All datetimes are generated at the start of the day so that times are ignored.
+  `from-dt` should be an earlier or equal date to `until-dt`."
   [from-dt until-dt]
-  (periodic-seq from-dt
-                (t/plus until-dt (t/days 1))
-                (t/days 1)))
+  (let [from-dt (t/with-time-at-start-of-day from-dt)
+        until-dt (t/with-time-at-start-of-day until-dt)]
+    (periodic-seq from-dt
+                  (t/plus until-dt (t/days 1))
+                  (t/days 1))))
 
 (defn day-of-week-keyword
   "Returns the day of week of a `DateTime`, in keyword form."

--- a/api/src/api/dt_util.clj
+++ b/api/src/api/dt_util.clj
@@ -44,9 +44,11 @@
 
 (defn days-spanned-between-datetimes
   "Returns the number of days spanned from `from-dt` to `until-dt`, inclusive.
-  For instance, today until tomorrow would be 2 days spanned."
+  For instance, today until tomorrow would be 2 days spanned.
+  `from-dt` should be an earlier or equal date to `until-dt`."
   [from-dt until-dt]
   (-> from-dt
       t/with-time-at-start-of-day  ; Bring `from-dt` to start of day so that times don't interfere
       (t/interval until-dt)
-      t/in-days))
+      t/in-days
+      inc))

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -7,7 +7,8 @@
 
 (def default-frequency-stats {:total_fragments 0, :successful_fragments 0, :total_done 0,
                               :current_fragment_streak 0, :best_fragment_streak 0,
-                              :current_fragment_total 0, :current_fragment_goal 0, :current_fragment_days_left 0})
+                              :current_fragment_total 0, :current_fragment_goal 0, :current_fragment_days_left 0,
+                              :habit_has_started false})
 
 (defn get-habit-goal-fragment-length
   "Returns the number of days within each habit goal fragment, given a goal frequency `freq`.
@@ -162,4 +163,5 @@
         habit-goal-fragments (get-habit-goal-fragments sorted-habit-data current-date (:type_name habit) freq)]
     (if (nil? habit-goal-fragments)
       (assoc default-frequency-stats :habit_id (:_id habit))
-      (compute-freq-stats-from-habit-goal-fragments habit-goal-fragments habit freq))))
+      (-> (compute-freq-stats-from-habit-goal-fragments habit-goal-fragments habit freq)
+          (assoc :habit_has_started true)))))

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -124,9 +124,9 @@
   of `current-fragment`, whose `:end-date` field was cut short at the current date during construction.
   Only ever treats the current fragment as successful for good habits, and only ever treats it as failed for bad
   habits; we don't punish unfinished good habits or reward unfinished bad habits."
-  [freq-stats current-fragment freq habit]
-  (let [treat-as-successful (and (= (:type_name habit) "good_habit") (:successful current-fragment))
-        treat-as-failed (and (= (:type_name habit) "bad_habit") (not (:successful current-fragment)))]
+  [freq-stats current-fragment freq habit-type]
+  (let [treat-as-successful (and (= habit-type "good_habit") (:successful current-fragment))
+        treat-as-failed (and (= habit-type "bad_habit") (not (:successful current-fragment)))]
     (as-> freq-stats $
           (update $ :total_fragments (if (or treat-as-successful treat-as-failed) inc identity))
           (update $ :successful_fragments (if treat-as-successful inc identity))
@@ -149,7 +149,7 @@
           (reduce update-freq-stats-with-past-fragment
                   freq-stats
                   past-fragments)
-          (update-freq-stats-with-current-fragment freq-stats current-fragment freq habit))))
+          (update-freq-stats-with-current-fragment freq-stats current-fragment freq (:type_name habit)))))
 
 (defn get-freq-stats-for-habit
   "Computes a `habit_frequency_stats` for a habit based on habit data from `current-date` or earlier."

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -91,21 +91,21 @@
 
 (defn evaluate-habit-goal-fragment
   "Evaluates `:total-done` and `:successful` fields of a habit goal fragment."
-  [habit-goal-fragment habit-data habit freq]
+  [habit-goal-fragment habit-data habit-type freq]
   (let [habit-data-during-fragment (get-habit-data-during-fragment habit-data habit-goal-fragment)]
     (-> habit-goal-fragment
         (evaluate-habit-goal-fragment-total-done habit-data-during-fragment)
-        (evaluate-habit-goal-fragment-successful (:type_name habit) freq))))
+        (evaluate-habit-goal-fragment-successful habit-type freq))))
 
 (defn get-habit-goal-fragments
   "Creates and evaluates habit goal fragments for a habit based on data from `current-date` or earlier.
   Returns `nil` if `sorted-habit-data` is empty, i.e. the habit has no relevant data."
-  [sorted-habit-data current-date habit freq]
+  [sorted-habit-data current-date habit-type freq]
   (if-not (empty? sorted-habit-data)
     (let [habit-start-date (get-habit-start-date sorted-habit-data freq)
           partitioned-datetimes (partition-datetimes-based-on-habit-goal freq habit-start-date current-date)
           habit-goal-fragments (map #(create-habit-goal-fragment %) partitioned-datetimes)]
-      (map #(evaluate-habit-goal-fragment % sorted-habit-data habit freq) habit-goal-fragments))))
+      (map #(evaluate-habit-goal-fragment % sorted-habit-data habit-type freq) habit-goal-fragments))))
 
 (defn update-freq-stats-with-past-fragment
   "Updates fields of a `habit_frequency_stats` based on a past habit goal fragment."
@@ -158,7 +158,7 @@
                                (filter #(= (:habit_id %) (:_id habit)))
                                (sort-by :date)),
         freq (get-frequency habit),
-        habit-goal-fragments (get-habit-goal-fragments sorted-habit-data current-date habit freq)]
+        habit-goal-fragments (get-habit-goal-fragments sorted-habit-data current-date (:type_name habit) freq)]
     (if (nil? habit-goal-fragments)
       (assoc default-frequency-stats :habit_id (:_id habit))
       (compute-freq-stats-from-habit-goal-fragments habit-goal-fragments habit freq))))

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -32,7 +32,7 @@
   "Returns the `DateTime` on which we consider a habit to have started, given its data and goal.
   If `freq` is based on the calendar week (Monday to Sunday), returns the Monday of the first `habit_day_record`.
   Otherwise just returns the date of the first `habit_day_record`.
-  Assumes `sorted-habit-data` is sorted increasingly by date."
+  Assumes `sorted-habit-data` is sorted increasingly by date and non-empty."
   [sorted-habit-data freq]
   (let [date-of-first-habit-day-record (:date (first sorted-habit-data))]
     (if (= (:type_name freq) "total_week_frequency")

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -49,7 +49,7 @@
 
 (defn create-habit-goal-fragment
   "Constructs a habit goal fragment from a list of consecutive DateTimes.
-  `datetimes` should be nonempty and correspond to a habit goal fragment.
+  `datetimes` should be nonempty, be sorted increasingly by date, and correspond to a habit goal fragment.
   Initializes `:total-done` to 0 and `:successful` to false."
   [datetimes]
   {:start-date (first datetimes),

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -44,8 +44,8 @@
   Boundaries are inclusive, with respect to `from-date` and `until-date`."
   [freq from-date until-date]
   (let [datetimes (get-consecutive-datetimes from-date until-date),
-        n (get-habit-goal-fragment-length freq)]
-    (partition-all n datetimes)))
+        fragment-length (get-habit-goal-fragment-length freq)]
+    (partition-all fragment-length datetimes)))
 
 (defn create-habit-goal-fragment
   "Constructs a habit goal fragment from a list of consecutive DateTimes.

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -152,8 +152,9 @@
           (update-freq-stats-with-current-fragment freq-stats current-fragment freq (:type_name habit)))))
 
 (defn get-freq-stats-for-habit
-  "Computes a `habit_frequency_stats` for a habit based on habit data from `current-date` or earlier."
-  [db habit all-habit-data-until-current-date current-date]
+  "Computes a `habit_frequency_stats` for `habit` based on habit data from `current-date` or earlier.
+  `all-habit-data-until-current-date` may include data from other habits."
+  [habit all-habit-data-until-current-date current-date]
   (let [sorted-habit-data (->> all-habit-data-until-current-date
                                (filter #(= (:habit_id %) (:_id habit)))
                                (sort-by :date)),

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -153,8 +153,8 @@
 
 (defn get-freq-stats-for-habit
   "Computes a `habit_frequency_stats` for a habit based on habit data from `current-date` or earlier."
-  [db habit all-habit-data current-date]
-  (let [sorted-habit-data (->> all-habit-data
+  [db habit all-habit-data-until-current-date current-date]
+  (let [sorted-habit-data (->> all-habit-data-until-current-date
                                (filter #(= (:habit_id %) (:_id habit)))
                                (sort-by :date)),
         freq (get-frequency habit),

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -1,0 +1,154 @@
+(ns api.freq-stats-util
+  "A namespace for holding utilities related to calculation of performance statistics."
+  (:require [api.dt-util :refer [date-geq?, date-leq?, first-monday-before-datetime, get-consecutive-datetimes,
+                                 day-of-week-keyword, days-spanned-between-datetimes]]
+            [api.habit-util :refer [get-frequency]]
+            [clj-time.core :as t]))
+
+(def default-frequency-stats {:total_fragments 0, :successful_fragments 0, :total_done 0,
+                              :current_fragment_streak 0, :best_fragment_streak 0,
+                              :current_fragment_total 0, :current_fragment_goal 0, :current_fragment_days_left 0})
+
+(defn get-habit-goal-fragment-length
+  "Returns the number of days within each habit goal fragment, given a goal frequency `freq`.
+  A habit goal fragment is a fragment of time that we will treat as either a success or a failure for a habit."
+  [freq]
+  (condp = (:type_name freq)
+         "specific_day_of_week_frequency" 1,
+         "total_week_frequency" 7,
+         "every_x_days_frequency" (:days freq)))
+
+(defn get-habit-goal-amount-for-datetime
+  "Returns the target/threshold amount for a particular DateTime, given the goal frequency."
+  [dt freq]
+  (condp = (:type_name freq)
+         "specific_day_of_week_frequency" (-> dt
+                                              day-of-week-keyword
+                                              freq),
+         "total_week_frequency" (:week freq),
+         "every_x_days_frequency" (:times freq)))
+
+(defn get-habit-start-date
+  "Returns the `DateTime` on which we consider a habit to have started, given its data and goal.
+  If `freq` is based on the calendar week (Monday to Sunday), returns the Monday of the first `habit_day_record`.
+  Otherwise just returns the date of the first `habit_day_record`.
+  Assumes `sorted-habit-data` is sorted increasingly by date."
+  [sorted-habit-data freq]
+  (let [date-of-first-habit-day-record (:date (first sorted-habit-data))]
+    (if (= (:type_name freq) "total_week_frequency")
+      (first-monday-before-datetime date-of-first-habit-day-record)
+      date-of-first-habit-day-record)))
+
+(defn partition-datetimes-based-on-habit-goal
+  "Returns a partition of consecutive DateTimes corresponding to habit goal fragments.
+  Boundaries are inclusive, with respect to `from-date` and `until-date`."
+  [freq from-date until-date]
+  (let [datetimes (get-consecutive-datetimes from-date until-date),
+        n (get-habit-goal-fragment-length freq)]
+    (partition-all n datetimes)))
+
+(defn create-habit-goal-fragment
+  "Constructs a habit goal fragment from a list of consecutive DateTimes.
+  `datetimes` should be nonempty and correspond to a habit goal fragment.
+  Initializes `:total-done` to 0 and `:successful` to false."
+  [datetimes]
+  {:start-date (first datetimes),
+   :end-date (last datetimes),
+   :total-done 0,
+   :successful false})
+
+(defn span-of-habit-goal-fragment
+  "Gets the number of days spanned by `habit-goal-fragment`."
+  [habit-goal-fragment]
+  (days-spanned-between-datetimes (:start-date habit-goal-fragment) (:end-date habit-goal-fragment)))
+
+(defn during-habit-goal-fragment?
+  "Returns true iff `datetime` occurs during `habit-goal-fragment`."
+  [datetime habit-goal-fragment]
+  (and (date-geq? datetime (:start-date habit-goal-fragment))
+       (date-leq? datetime (:end-date habit-goal-fragment))))
+
+(defn get-habit-data-during-fragment
+  "Finds all `habit_day_record`s in `habit-data` that occur during `habit-goal-fragment`."
+  [habit-data habit-goal-fragment]
+  (filter #(during-habit-goal-fragment? (:date %) habit-goal-fragment) habit-data))
+
+(defn evaluate-habit-goal-fragment-total-done
+  "Updates the `:total-done` field of `habit-goal-fragment` based on a list of `habit_day_record`s."
+  [habit-goal-fragment habit-data-during-fragment]
+  (reduce #(update %1 :total-done + (:amount %2))
+          habit-goal-fragment
+          habit-data-during-fragment))
+
+(defn evaluate-habit-goal-fragment-successful
+  "Evaluates the `:successful` field of `habit-goal-fragment` based on its `:total-done` field and the habit's goal."
+  [habit-goal-fragment habit freq]
+  (let [goal-amount (get-habit-goal-amount-for-datetime (:start-date habit-goal-fragment) freq)]
+    (assoc habit-goal-fragment
+           :successful ((if (= (:type_name habit) "good_habit") >= <=)
+                        (:total-done habit-goal-fragment)
+                        goal-amount))))
+
+(defn evaluate-habit-goal-fragment
+  "Evaluates `:total-done` and `:successful` fields of a habit goal fragment."
+  [habit-goal-fragment habit-data habit freq]
+  (let [habit-data-during-fragment (get-habit-data-during-fragment habit-data habit-goal-fragment)]
+    (-> habit-goal-fragment
+        (evaluate-habit-goal-fragment-total-done habit-data-during-fragment)
+        (evaluate-habit-goal-fragment-successful habit freq))))
+
+(defn get-habit-goal-fragments
+  "Creates and evaluates habit goal fragments for a habit based on data from `current-date` or earlier.
+  Returns `nil` if `sorted-habit-data` is empty, i.e. the habit has no relevant data."
+  [sorted-habit-data current-date habit freq]
+  (if-not (empty? sorted-habit-data)
+    (let [habit-start-date (get-habit-start-date sorted-habit-data freq)
+          partitioned-datetimes (partition-datetimes-based-on-habit-goal freq habit-start-date current-date)
+          habit-goal-fragments (map #(create-habit-goal-fragment %) partitioned-datetimes)]
+      (map #(evaluate-habit-goal-fragment % sorted-habit-data habit freq) habit-goal-fragments))))
+
+(defn update-freq-stats-with-past-fragment
+  "Updates fields of a `habit_frequency_stats` based on a past habit goal fragment."
+  [habit-frequency-stats habit-goal-fragment]
+  (let [successful (:successful habit-goal-fragment)]
+    (as-> habit-frequency-stats $
+          (update $ :total_fragments inc)
+          (update $ :successful_fragments (if successful inc identity))
+          (update $ :total_done + (:total-done habit-goal-fragment))
+          (update $ :current_fragment_streak (if successful inc (constantly 0)))
+          (assoc $ :best_fragment_streak (max (:current_fragment_streak $) (:best_fragment_streak $))))))
+
+(defn update-freq-stats-with-current-fragment
+  "Updates fields of a `habit_frequency_stats` based on the current habit goal fragment and its goal `freq`.
+  Computes `:current_fragment_days_left` based on the fragment length defined by `freq` minus the span
+  of `current-fragment`, whose `:end-date` field was cut short at the current date during construction."
+  [freq-stats current-fragment freq]
+  (-> freq-stats
+      (update :total_done + (:total-done current-fragment))
+      (assoc :current_fragment_total (:total-done current-fragment))
+      (assoc :current_fragment_goal (get-habit-goal-amount-for-datetime (:start-date current-fragment) freq))
+      (assoc :current_fragment_days_left (- (get-habit-goal-fragment-length freq)
+                                            (span-of-habit-goal-fragment current-fragment)))))
+
+(defn compute-freq-stats-from-habit-goal-fragments
+  "Computes a `habit_frequency_stats` based on a list of habit goal fragments with goal `freq`."
+  [habit-goal-fragments habit freq]
+  (let [past-fragments (butlast habit-goal-fragments)
+        current-fragment (last habit-goal-fragments)]
+    (as-> (assoc default-frequency-stats :habit_id (:_id habit)) freq-stats
+          (reduce update-freq-stats-with-past-fragment
+                  freq-stats
+                  past-fragments)
+          (update-freq-stats-with-current-fragment freq-stats current-fragment freq))))
+
+(defn get-freq-stats-for-habit
+  "Computes a `habit_frequency_stats` for a habit based on habit data from `current-date` or earlier."
+  [db habit all-habit-data current-date]
+  (let [sorted-habit-data (->> all-habit-data
+                               (filter #(= (:habit_id %) (:_id habit)))
+                               (sort-by :date)),
+        freq (get-frequency habit),
+        habit-goal-fragments (get-habit-goal-fragments sorted-habit-data current-date habit freq)]
+    (if (nil? habit-goal-fragments)
+      (assoc default-frequency-stats :habit_id (:_id habit))
+      (compute-freq-stats-from-habit-goal-fragments habit-goal-fragments habit freq))))

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -81,11 +81,11 @@
           habit-data-during-fragment))
 
 (defn evaluate-habit-goal-fragment-successful
-  "Evaluates the `:successful` field of `habit-goal-fragment` based on its `:total-done` field and the habit's goal."
-  [habit-goal-fragment habit freq]
+  "Evaluates the `:successful` field of `habit-goal-fragment` based on its `:total-done` field, the type of habit, and the habit's goal."
+  [habit-goal-fragment habit-type freq]
   (let [goal-amount (get-habit-goal-amount-for-datetime (:start-date habit-goal-fragment) freq)]
     (assoc habit-goal-fragment
-           :successful ((if (= (:type_name habit) "good_habit") >= <=)
+           :successful ((if (= habit-type "good_habit") >= <=)
                         (:total-done habit-goal-fragment)
                         goal-amount))))
 
@@ -95,7 +95,7 @@
   (let [habit-data-during-fragment (get-habit-data-during-fragment habit-data habit-goal-fragment)]
     (-> habit-goal-fragment
         (evaluate-habit-goal-fragment-total-done habit-data-during-fragment)
-        (evaluate-habit-goal-fragment-successful habit freq))))
+        (evaluate-habit-goal-fragment-successful (:type_name habit) freq))))
 
 (defn get-habit-goal-fragments
   "Creates and evaluates habit goal fragments for a habit based on data from `current-date` or earlier.

--- a/api/src/api/freq_stats_util.clj
+++ b/api/src/api/freq_stats_util.clj
@@ -141,7 +141,7 @@
                                                   (span-of-habit-goal-fragment current-fragment))))))
 
 (defn compute-freq-stats-from-habit-goal-fragments
-  "Computes a `habit_frequency_stats` based on a list of habit goal fragments with goal `freq`."
+  "Computes a `habit_frequency_stats` based on a non-empty list of habit goal fragments with goal `freq`."
   [habit-goal-fragments habit freq]
   (let [past-fragments (butlast habit-goal-fragments)
         current-fragment (last habit-goal-fragments)]

--- a/api/src/api/habit_util.clj
+++ b/api/src/api/habit_util.clj
@@ -1,0 +1,9 @@
+(ns api.habit-util
+  "A namespace for holding utilities related to habits and their fields.")
+
+(defn get-frequency
+  "Returns the target/threshold `frequency` object of a habit."
+  [habit]
+  (if (= (:type_name habit) "good_habit")
+    (:target_frequency habit)
+    (:threshold_frequency habit)))

--- a/api/src/api/schema.clj
+++ b/api/src/api/schema.clj
@@ -80,27 +80,27 @@
 
 (defn resolve-mutation-set-habit-data
   "@refer `db/set-habit-data`."
-  [context {:keys [habit_id amount date] :as all} value]
+  [context {:keys [date] :as all} value]
   (db/set-habit-data (assoc (dissoc all :date) :date-time (date-from-y-m-d-map date))))
 
 (defn resolve-get-habit-data
   "@refer `db/get-habit-data`."
-  [context {:keys [after_date for_habit] :as all} value]
-  (db/get-habit-data all))
+  [context args value]
+  (db/get-habit-data args))
 
 (defn resolve-mutation-delete-habit
   "@refer `db/delete-habit`."
-  [context {:keys [habit_id] :as all} value]
-  (db/delete-habit all))
+  [context args value]
+  (db/delete-habit args))
 
 (defn resolve-mutation-set-suspend-habit
   "@refer `db/set-suspend-habit`."
-  [context {:keys [habit_id suspended] :as all} value]
-  (db/set-suspend-habit all))
+  [context args value]
+  (db/set-suspend-habit args))
 
 (defn resolve-query-get-frequency-stats
   "@refer `db/get-frequency-stats`."
-  [context {:keys [habit_ids current_client_date] :as all} value]
+  [context {:keys [current_client_date] :as all} value]
   (map tag-type (db/get-frequency-stats (assoc all :current_client_date (date-from-y-m-d-map current_client_date)))))
 
 (defn resolver-map

--- a/api/src/api/schema.clj
+++ b/api/src/api/schema.clj
@@ -71,33 +71,37 @@
 (defn resolve-get-habits
   "@refer `db/get-habits`."
   [context args value]
-  (map tag-type (db/get-habits)))
+  (map tag-type (db/get-habits args)))
 
 (defn resolve-mutation-add-habit
   "@refer `db/add-habit`."
-  [context {:keys [create_habit_data] } value]
-  (tag-type (db/add-habit (unnest-tagged-unions-on-input-object create_habit_data))))
+  [context {:keys [create_habit_data] :as all} value]
+  (tag-type (db/add-habit (assoc all :habit (unnest-tagged-unions-on-input-object create_habit_data)))))
 
 (defn resolve-mutation-set-habit-data
   "@refer `db/set-habit-data`."
-  [context {:keys [habit_id amount date]} value]
-  (let [date-time (date-from-y-m-d-map date)]
-    (db/set-habit-data habit_id amount date-time)))
+  [context {:keys [habit_id amount date] :as all} value]
+  (db/set-habit-data (assoc (dissoc all :date) :date-time (date-from-y-m-d-map date))))
 
 (defn resolve-get-habit-data
   "@refer `db/get-habit-data`."
-  [context {:keys [after_date for_habit]} value]
-  (db/get-habit-data after_date for_habit))
+  [context {:keys [after_date for_habit] :as all} value]
+  (db/get-habit-data all))
 
 (defn resolve-mutation-delete-habit
   "@refer `db/delete-habit`."
-  [context {:keys [habit_id]} value]
-  (db/delete-habit habit_id))
+  [context {:keys [habit_id] :as all} value]
+  (db/delete-habit all))
 
 (defn resolve-mutation-set-suspend-habit
   "@refer `db/set-suspend-habit`."
-  [context {:keys [habit_id, suspended]} value]
-  (db/set-suspend-habit habit_id suspended))
+  [context {:keys [habit_id suspended] :as all} value]
+  (db/set-suspend-habit all))
+
+(defn resolve-query-get-frequency-stats
+  "@refer `db/get-frequency-stats`."
+  [context {:keys [habit_ids current_client_date] :as all} value]
+  (map tag-type (db/get-frequency-stats (assoc all :current_client_date (date-from-y-m-d-map current_client_date)))))
 
 (defn resolver-map
   []
@@ -109,7 +113,8 @@
    :query/get-habit-data (create-async-resolver resolve-get-habit-data)
    :query/date-to-y-m-d-format (create-date-to-y-m-d-resolver :date)
    :query/resolve-mutation-delete-habit (create-async-resolver resolve-mutation-delete-habit)
-   :query/resolve-mutation-set-suspend-habit (create-async-resolver resolve-mutation-set-suspend-habit)})
+   :query/resolve-mutation-set-suspend-habit (create-async-resolver resolve-mutation-set-suspend-habit)
+   :query/get-frequency-stats (create-async-resolver resolve-query-get-frequency-stats)})
 
 (defn load-schema
   []

--- a/api/src/api/util.clj
+++ b/api/src/api/util.clj
@@ -13,6 +13,14 @@
   [{:keys [year month day]}]
   (t/date-time year month day))
 
+(defn are-datetimes-same-date
+  "Input: two clj-time.core/date-time objects
+  Output: true iff they are on the same date (i.e. ignore time)"
+  [dt1 dt2]
+  (and (= (t/year dt1) (t/year dt2))
+       (= (t/month dt1) (t/month dt2))
+       (= (t/day dt1) (t/day dt2))))
+
 (defn value-map
   "Maps a function on the values of a map, returns a map with the updated values."
   [m f]

--- a/api/src/api/util.clj
+++ b/api/src/api/util.clj
@@ -13,14 +13,6 @@
   [{:keys [year month day]}]
   (t/date-time year month day))
 
-(defn are-datetimes-same-date
-  "Input: two clj-time.core/date-time objects
-  Output: true iff they are on the same date (i.e. ignore time)"
-  [dt1 dt2]
-  (and (= (t/year dt1) (t/year dt2))
-       (= (t/month dt1) (t/month dt2))
-       (= (t/day dt1) (t/day dt2))))
-
 (defn value-map
   "Maps a function on the values of a map, returns a map with the updated values."
   [m f]

--- a/api/test/api/core_test.clj
+++ b/api/test/api/core_test.clj
@@ -1,7 +1,0 @@
-(ns api.core-test
-  (:require [clojure.test :refer :all]
-            [api.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/api/test/api/db_test.clj
+++ b/api/test/api/db_test.clj
@@ -105,8 +105,8 @@
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 3 :date-time (t/plus today (t/hours 23))})
                   stats (get-frequency-stats {:db test_db :habit_ids [habit_id_str]})]
               (is (= stats [{:habit_id habit_id
-                             :total_fragments 2 :successful_fragments 1 :total_done 8
-                             :current_fragment_streak 1 :best_fragment_streak 1
+                             :total_fragments 3 :successful_fragments 2 :total_done 8
+                             :current_fragment_streak 2 :best_fragment_streak 2
                              :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 0}]))))))))
   (testing "Good habit, total week frequency"
     (let [habit (assoc default_habit
@@ -138,8 +138,8 @@
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 6 :date-time today})
                   stats (get-frequency-stats {:db test_db :habit_ids [habit_id_str]})]
               (is (supermap? stats [{:habit_id habit_id
-                                     :total_fragments 2 :successful_fragments 1 :total_done 14
-                                     :current_fragment_streak 0 :best_fragment_streak 1
+                                     :total_fragments 3 :successful_fragments 2 :total_done 14
+                                     :current_fragment_streak 1 :best_fragment_streak 1
                                      :current_fragment_total 6 :current_fragment_goal 5}]))))))))
   (testing "Good habit, every x days frequency"
     (let [habit (assoc default_habit

--- a/api/test/api/db_test.clj
+++ b/api/test/api/db_test.clj
@@ -92,7 +92,7 @@
           (is (= stats [{:habit_id habit_id
                          :total_fragments 1 :successful_fragments 1 :total_done 4
                          :current_fragment_streak 1 :best_fragment_streak 1
-                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0}])))
         (testing "and a failure habit record the day before"
           (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 1
                                    :date-time (t/minus today (t/days 2))})
@@ -100,14 +100,14 @@
             (is (= stats [{:habit_id habit_id
                            :total_fragments 2 :successful_fragments 1 :total_done 5
                            :current_fragment_streak 1 :best_fragment_streak 1
-                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0}])))
           (testing "and at 11pm today the user did 3 units"
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 3 :date-time (t/plus today (t/hours 23))})
                   stats (get-frequency-stats {:db test_db :habit_ids [habit_id_str]})]
               (is (= stats [{:habit_id habit_id
                              :total_fragments 2 :successful_fragments 1 :total_done 8
                              :current_fragment_streak 1 :best_fragment_streak 1
-                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 1}]))))))))
+                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 0}]))))))))
   (testing "Good habit, total week frequency"
     (let [habit (assoc default_habit
                        :type_name "good_habit"

--- a/api/test/api/db_test.clj
+++ b/api/test/api/db_test.clj
@@ -1,0 +1,206 @@
+(ns api.db-test
+  (:require [clojure.test :refer :all]
+            [clojure.data :refer [diff]]
+            [api.db :refer :all]
+            [monger.core :as mg]
+            [monger.db :as mdb]
+            [clj-time.core :as t]))
+
+; Useful variables
+(def test_conn (mg/connect))
+(def test_db (mg/get-db test_conn "test_db"))
+(def default_habit {:name "test habit" :description "test description" :unit_name_singular "test unit"
+                    :unit_name_plural "test units" :time_of_day :ANYTIME})
+(def today (t/today-at 0 0))
+(def default_frequency_stats {:total_fragments 0, :successful_fragments 0, :total_done 0,
+                              :current_fragment_streak 0, :best_fragment_streak 0,
+                              :current_fragment_total 0, :current_fragment_goal 0, :current_fragment_days_left 0})
+
+(defn add-habit-to-test-db
+  "Add a habit to the test database"
+  [habit]
+  (add-habit {:db test_db :habit habit}))
+
+(defn compare_clojure_habit_with_db_habit
+  "Returns true iff all fields of `clojure_habit` have the same value in `db_habit`.
+  Checks Keyword values in `clojure_habit` against the Keyword-ed version of the value in `db_habit`
+  since Keywords are converted to Strings by Monger.
+  Note that this function doesn't care if `db_habit` has a field that `clojure_habit` doesn't have."
+  [clojure_habit db_habit]
+  (every? (fn [key]
+           (let [clj_val (key clojure_habit)
+                 db_val (key db_habit)]
+             (if (= (type clj_val) clojure.lang.Keyword)
+               (= clj_val (keyword db_val))
+               (= clj_val db_val))))
+          (keys clojure_habit)))
+
+(defn supermap?
+  "Returns true iff all fields of `map2` have the same value in `map1`.
+  I.e., `map1` is a supermap of `map2`. Patent pending."
+  [map1 map2]
+  (nil? (first (diff map2 map1))))
+
+(deftest add-habit-test
+  (testing "No habits"
+    (is (= 0 (count (get-habits {:db test_db})))))
+  (let [habit_1 (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "total_week_frequency"
+                                          :week 6})
+        _ (add-habit-to-test-db habit_1)
+        all_habits (get-habits {:db test_db})]
+    (testing "One habit"
+      (is (= 1 (count all_habits)) "There should be one habit in the db")
+      (is (some #(compare_clojure_habit_with_db_habit habit_1 %) all_habits) "Habit 1 not added properly")
+      (is (every? #(= false (:suspended %)) all_habits) ":suspended field not set to false")
+      (is (every? #(not (nil? (:_id %))) all_habits) ":_id field not set"))
+    (let [habit_2 (assoc default_habit
+                         :type_name "bad_habit"
+                         :threshold_frequency {:type_name "every_x_days_frequency"
+                                               :days 4
+                                               :times 3})
+          _ (add-habit-to-test-db habit_2)
+          all_habits (get-habits {:db test_db})]
+      (testing "Two habits"
+        (is (= 2 (count all_habits)) "There should be two habits in the db")
+        (is (some #(compare_clojure_habit_with_db_habit habit_1 %) all_habits) "Habit 1 not added properly")
+        (is (some #(compare_clojure_habit_with_db_habit habit_2 %) all_habits) "Habit 2 not added properly")
+        (is (every? #(= false (:suspended %)) all_habits) ":suspended field not set to false")
+        (is (every? #(not (nil? (:_id %))) all_habits) ":_id field not set")))))
+
+(deftest get-frequency-stats-test
+  (testing "No habits added yet"
+    (is (= 0 (count (get-habits {:db test_db})))))
+  (testing "Good habit, specific day of week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "specific_day_of_week_frequency"
+                                          :monday 2 :tuesday 2 :wednesday 2 :thursday 2
+                                          :friday 2 :saturday 2 :sunday 2})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with no habit data"
+        (is (= 1 (count (get-habits {:db test_db}))) "There should only be one habit so far")
+        (is (= [(assoc default_frequency_stats :habit_id habit_id)]
+               (get-frequency-stats {:db test_db :habit_ids [habit_id]})))
+        (is (= [(assoc default_frequency_stats :habit_id habit_id)]
+               (get-frequency-stats {:db test_db})) "`habit_ids` should be an optional param"))
+      (testing "with a successful habit record yesterday"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 4
+                                 :date-time (t/minus today (t/days 1))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (= stats [{:habit_id habit_id
+                         :total_fragments 1 :successful_fragments 1 :total_done 4
+                         :current_fragment_streak 1 :best_fragment_streak 1
+                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+        (testing "and a failure habit record the day before"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 1
+                                   :date-time (t/minus today (t/days 2))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (= stats [{:habit_id habit_id
+                           :total_fragments 2 :successful_fragments 1 :total_done 5
+                           :current_fragment_streak 1 :best_fragment_streak 1
+                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 1}])))
+          (testing "and at 11pm today the user did 3 units"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 3 :date-time (t/plus today (t/hours 23))})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (= stats [{:habit_id habit_id
+                             :total_fragments 2 :successful_fragments 1 :total_done 8
+                             :current_fragment_streak 1 :best_fragment_streak 1
+                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 1}]))))))))
+  (testing "Good habit, total week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "total_week_frequency"
+                                          :week 5})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with last week as a failure"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 3
+                                 ; 7 days ago was in the previous week, which has now ended
+                                 :date-time (t/minus today (t/days 7))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 ; this week hasn't ended so we only track last week
+                                 :total_fragments 1 :successful_fragments 0 :total_done 3
+                                 :current_fragment_streak 0 :best_fragment_streak 0
+                                 :current_fragment_total 0 :current_fragment_goal 5}])))
+        (testing "and the week before as a success"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 5
+                                   :date-time (t/minus today (t/days 14))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 2 :successful_fragments 1 :total_done 8
+                                   :current_fragment_streak 0 :best_fragment_streak 1
+                                   :current_fragment_total 0 :current_fragment_goal 5}])))
+          (testing "and today the user did 6 units"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 6 :date-time today})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (supermap? stats [{:habit_id habit_id
+                                     :total_fragments 2 :successful_fragments 1 :total_done 14
+                                     :current_fragment_streak 0 :best_fragment_streak 1
+                                     :current_fragment_total 6 :current_fragment_goal 5}]))))))))
+  (testing "Good habit, every x days frequency"
+    (let [habit (assoc default_habit
+                       :type_name "good_habit"
+                       :target_frequency {:type_name "every_x_days_frequency"
+                                          :times 3 :days 5})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with the last fragment as a success"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 200
+                                 :date-time (t/minus today (t/days 5))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 :total_fragments 1 :successful_fragments 1 :total_done 200
+                                 :current_fragment_streak 1 :best_fragment_streak 1
+                                 :current_fragment_total 0 :current_fragment_goal 3}])))
+        (testing "and three fragments ago as a failure"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 2
+                                   :date-time (t/minus today (t/days 15))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 3 :successful_fragments 1 :total_done 202
+                                   :current_fragment_streak 1 :best_fragment_streak 1
+                                   :current_fragment_total 0 :current_fragment_goal 3}])))))))
+  (testing "Bad habit, total week frequency"
+    (let [habit (assoc default_habit
+                       :type_name "bad_habit"
+                       :threshold_frequency {:type_name "total_week_frequency"
+                                             :week 20})
+          final_habit (add-habit-to-test-db habit)
+          habit_id (str (:_id final_habit))]
+      (testing "with last week as a success"
+        (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 0
+                                 :date-time (t/minus today (t/days 7))})
+              stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+          (is (supermap? stats [{:habit_id habit_id
+                                 :total_fragments 1 :successful_fragments 1 :total_done 0
+                                 :current_fragment_streak 1 :best_fragment_streak 1
+                                 :current_fragment_total 0 :current_fragment_goal 20}])))
+        (testing "and the week before that as a success"
+          (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 20
+                                   :date-time (t/minus today (t/days 14))})
+                stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+            (is (supermap? stats [{:habit_id habit_id
+                                   :total_fragments 2 :successful_fragments 2 :total_done 20
+                                   :current_fragment_streak 2 :best_fragment_streak 2
+                                   :current_fragment_total 0 :current_fragment_goal 20}])))
+          (testing "and three weeks ago as a failure"
+            (let [_ (set-habit-data {:db test_db :habit_id habit_id :amount 21
+                                     :date-time (t/minus today (t/days 21))})
+                  stats (get-frequency-stats {:db test_db :habit_ids [habit_id]})]
+              (is (supermap? stats [{:habit_id habit_id
+                                     :total_fragments 3 :successful_fragments 2 :total_done 41
+                                     :current_fragment_streak 2 :best_fragment_streak 2
+                                     :current_fragment_total 0 :current_fragment_goal 20}])))))))))
+
+(defn drop-test-db-fixture
+  "Drop test database before and after each test"
+  [f]
+  (mdb/drop-db test_db)
+  (f)
+  (mdb/drop-db test_db))
+
+(use-fixtures :each drop-test-db-fixture)

--- a/api/test/api/db_test.clj
+++ b/api/test/api/db_test.clj
@@ -92,7 +92,8 @@
           (is (= stats [{:habit_id habit_id
                          :total_fragments 1 :successful_fragments 1 :total_done 4
                          :current_fragment_streak 1 :best_fragment_streak 1
-                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0}])))
+                         :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0
+                         :habit_has_started true}])))
         (testing "and a failure habit record the day before"
           (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 1
                                    :date-time (t/minus today (t/days 2))})
@@ -100,14 +101,16 @@
             (is (= stats [{:habit_id habit_id
                            :total_fragments 2 :successful_fragments 1 :total_done 5
                            :current_fragment_streak 1 :best_fragment_streak 1
-                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0}])))
+                           :current_fragment_total 0 :current_fragment_goal 2 :current_fragment_days_left 0
+                           :habit_has_started true}])))
           (testing "and at 11pm today the user did 3 units"
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 3 :date-time (t/plus today (t/hours 23))})
                   stats (get-frequency-stats {:db test_db :habit_ids [habit_id_str]})]
               (is (= stats [{:habit_id habit_id
                              :total_fragments 3 :successful_fragments 2 :total_done 8
                              :current_fragment_streak 2 :best_fragment_streak 2
-                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 0}]))))))))
+                             :current_fragment_total 3 :current_fragment_goal 2 :current_fragment_days_left 0
+                             :habit_has_started true}]))))))))
   (testing "Good habit, total week frequency"
     (let [habit (assoc default_habit
                        :type_name "good_habit"
@@ -125,7 +128,8 @@
                                  ; this week hasn't ended so we only track last week
                                  :total_fragments 1 :successful_fragments 0 :total_done 3
                                  :current_fragment_streak 0 :best_fragment_streak 0
-                                 :current_fragment_total 0 :current_fragment_goal 5}])))
+                                 :current_fragment_total 0 :current_fragment_goal 5
+                                 :habit_has_started true}])))
         (testing "and the week before as a success"
           (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 5
                                    :date-time (t/minus today (t/days 14))})
@@ -133,14 +137,16 @@
             (is (supermap? stats [{:habit_id habit_id
                                    :total_fragments 2 :successful_fragments 1 :total_done 8
                                    :current_fragment_streak 0 :best_fragment_streak 1
-                                   :current_fragment_total 0 :current_fragment_goal 5}])))
+                                   :current_fragment_total 0 :current_fragment_goal 5
+                                   :habit_has_started true}])))
           (testing "and today the user did 6 units"
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 6 :date-time today})
                   stats (get-frequency-stats {:db test_db :habit_ids [habit_id_str]})]
               (is (supermap? stats [{:habit_id habit_id
                                      :total_fragments 3 :successful_fragments 2 :total_done 14
                                      :current_fragment_streak 1 :best_fragment_streak 1
-                                     :current_fragment_total 6 :current_fragment_goal 5}]))))))))
+                                     :current_fragment_total 6 :current_fragment_goal 5
+                                     :habit_has_started true}]))))))))
   (testing "Good habit, every x days frequency"
     (let [habit (assoc default_habit
                        :type_name "good_habit"
@@ -156,7 +162,8 @@
           (is (supermap? stats [{:habit_id habit_id
                                  :total_fragments 1 :successful_fragments 1 :total_done 200
                                  :current_fragment_streak 1 :best_fragment_streak 1
-                                 :current_fragment_total 0 :current_fragment_goal 3}])))
+                                 :current_fragment_total 0 :current_fragment_goal 3
+                                 :habit_has_started true}])))
         (testing "and three fragments ago as a failure"
           (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 2
                                    :date-time (t/minus today (t/days 15))})
@@ -164,7 +171,8 @@
             (is (supermap? stats [{:habit_id habit_id
                                    :total_fragments 3 :successful_fragments 1 :total_done 202
                                    :current_fragment_streak 1 :best_fragment_streak 1
-                                   :current_fragment_total 0 :current_fragment_goal 3}])))))))
+                                   :current_fragment_total 0 :current_fragment_goal 3
+                                   :habit_has_started true}])))))))
   (testing "Bad habit, total week frequency"
     (let [habit (assoc default_habit
                        :type_name "bad_habit"
@@ -180,7 +188,8 @@
           (is (supermap? stats [{:habit_id habit_id
                                  :total_fragments 1 :successful_fragments 1 :total_done 0
                                  :current_fragment_streak 1 :best_fragment_streak 1
-                                 :current_fragment_total 0 :current_fragment_goal 20}])))
+                                 :current_fragment_total 0 :current_fragment_goal 20
+                                 :habit_has_started true}])))
         (testing "and the week before that as a success"
           (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 20
                                    :date-time (t/minus today (t/days 14))})
@@ -188,7 +197,8 @@
             (is (supermap? stats [{:habit_id habit_id
                                    :total_fragments 2 :successful_fragments 2 :total_done 20
                                    :current_fragment_streak 2 :best_fragment_streak 2
-                                   :current_fragment_total 0 :current_fragment_goal 20}])))
+                                   :current_fragment_total 0 :current_fragment_goal 20
+                                   :habit_has_started true}])))
           (testing "and three weeks ago as a failure"
             (let [_ (set-habit-data {:db test_db :habit_id habit_id_str :amount 21
                                      :date-time (t/minus today (t/days 21))})
@@ -196,7 +206,8 @@
               (is (supermap? stats [{:habit_id habit_id
                                      :total_fragments 3 :successful_fragments 2 :total_done 41
                                      :current_fragment_streak 2 :best_fragment_streak 2
-                                     :current_fragment_total 0 :current_fragment_goal 20}])))))))))
+                                     :current_fragment_total 0 :current_fragment_goal 20
+                                     :habit_has_started true}])))))))))
 
 (defn drop-test-db-fixture
   "Drop test database before and after each test"

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -64,15 +64,29 @@
            (and (date-geq? dt dt)
                 (date-leq? dt dt))))
 
-(defspec date-geq?-test
+(defspec date-geq?-true-test
          number-of-test-check-iterations
          (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
            (date-geq? dt-b dt-a)))
 
-(defspec date-leq?-test
+(defspec date-geq?-false-test
+         number-of-test-check-iterations
+         (prop/for-all [dt-a generate-random-datetime
+                        num-days-later gen/s-pos-int]
+           (let [dt-b (random-datetime-on-given-date (t/plus dt-a (t/days num-days-later)))]
+             (not (date-geq? dt-a dt-b)))))
+
+(defspec date-leq?-true-test
          number-of-test-check-iterations
          (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
            (date-leq? dt-a dt-b)))
+
+(defspec date-leq?-false-test
+         number-of-test-check-iterations
+         (prop/for-all [dt-a generate-random-datetime
+                        num-days-later gen/s-pos-int]
+           (let [dt-b (random-datetime-on-given-date (t/plus dt-a (t/days num-days-later)))]
+             (not (date-leq? dt-b dt-a)))))
 
 (defspec first-monday-before-datetime-test
          number-of-test-check-iterations

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
-            [clojure.test :refer [deftest, testing, is]]
             [api.dt-util :refer [date-geq?, date-leq?, first-monday-before-datetime,
                                  days-spanned-between-datetimes, get-consecutive-datetimes]]
             [clj-time.core :as t]))
@@ -21,14 +20,14 @@
     (t/plus (t/date-time 2018 5 7)  ; May 7 2018 was a Monday
             (t/weeks weeks-to-add))))
 
-(defn get-later-datetime
-  "Returns a `DateTime` instance `days-to-add` days later than `dt`, at time `hour`:`minute`."
-  [dt days-to-add hour minute]
-  (-> dt
-      t/with-time-at-start-of-day
-      (t/plus (t/days days-to-add)
-              (t/hours hour)
-              (t/minutes minute))))
+(defn generate-random-datetime-d-days-later
+  "Returns a generator for a `DateTime` instance `d` days later than `dt`, with a random time."
+  [dt d]
+  (gen/let [hour generate-random-hour,
+            minute generate-random-minute]
+    (-> dt
+        t/with-time-at-start-of-day
+        (t/plus (t/days d) (t/hours hour) (t/minutes minute)))))
 
 ; Generates a sorted two-element vector of DateTimes
 (def generate-two-random-sorted-datetimes
@@ -39,10 +38,8 @@
 ; Generates two random `DateTime`s, with `until-date` being `days-apart` days later than `from-date`. Returns a map of the values.
 (def generate-two-random-datetimes-with-days-apart
   (gen/let [from-date generate-random-datetime,
-            days-apart gen/nat,
-            until-date-hour generate-random-hour,
-            until-date-minute generate-random-minute]
-    (let [until-date (get-later-datetime from-date days-apart until-date-hour until-date-minute)]
+            days-apart gen/nat]
+    (let [until-date (gen/generate (generate-random-datetime-d-days-later from-date days-apart))]
       {:from-date from-date, :until-date until-date, :days-apart days-apart})))
 
 (defspec date-geq?-and-date-leq?-equal-dates-test
@@ -68,16 +65,16 @@
            (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add))]
              (= monday-dt (first-monday-before-datetime later-in-week-dt)))))
 
-(deftest get-consecutive-datetimes-test
-         (testing "Today until today"
-                  (let [dt-a (t/today-at 3 3)
-                        dt-b (t/today-at 2 2)]
-                    (is (= [(t/today-at 0 0)] (get-consecutive-datetimes dt-a dt-b)))))
-         (testing "Today until tomorrow"
-                  (let [dt-a (t/today-at 3 3)
-                        dt-b (get-later-datetime dt-a 1 2 2)]
-                    (is (= [(t/today-at 0 0), (t/plus (t/today-at 0 0) (t/days 1))]
-                           (get-consecutive-datetimes dt-a dt-b))))))
+(defspec get-consecutive-datetimes-test
+         20
+         (let [today-at-start-of-day (t/today-at 0 0)]
+           (prop/for-all [random-today-dt-a (generate-random-datetime-d-days-later today-at-start-of-day 0)
+                          random-today-dt-b (generate-random-datetime-d-days-later today-at-start-of-day 0)
+                          random-tomorrow-dt (generate-random-datetime-d-days-later today-at-start-of-day 1)]
+             (and (= [today-at-start-of-day]
+                     (get-consecutive-datetimes random-today-dt-a random-today-dt-b))
+                  (= [today-at-start-of-day, (t/plus today-at-start-of-day (t/days 1))]
+                     (get-consecutive-datetimes random-today-dt-a random-tomorrow-dt))))))
 
 (defspec get-consecutive-datetimes-count-test
          10

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -80,12 +80,6 @@
                (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc days-apart)))
                   (get-consecutive-datetimes from-date until-date)))))
 
-(defspec get-consecutive-datetimes-count-test
-         number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
-           (= (inc days-apart)
-              (count (get-consecutive-datetimes from-date until-date)))))
-
 (defspec days-spanned-between-datetimes-test
          number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -8,8 +8,13 @@
 
 (def number-of-test-check-iterations 30)
 
+;; Generators
+;; ---------------------------------------------------------------------------
+
 (def generate-random-hour (gen/choose 0 23))
+
 (def generate-random-minute (gen/choose 0 59))
+
 (def generate-random-datetime
   (gen/let [hour generate-random-hour,
             minute generate-random-minute,
@@ -49,6 +54,9 @@
     (let [until-date (t/plus (random-datetime-on-given-date from-date)
                              (t/days num-days-apart))]
       {:from-date from-date, :until-date until-date, :num-days-apart num-days-apart})))
+
+;; Tests
+;; ---------------------------------------------------------------------------
 
 (defspec date-geq?-and-date-leq?-equal-dates-test
          number-of-test-check-iterations

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -6,6 +6,8 @@
                                  days-spanned-between-datetimes, get-consecutive-datetimes]]
             [clj-time.core :as t]))
 
+(def number-of-test-check-iterations 30)
+
 (def generate-random-hour (gen/choose 0 23))
 (def generate-random-minute (gen/choose 0 59))
 (def generate-random-datetime
@@ -44,30 +46,30 @@
       {:from-date from-date, :until-date until-date, :days-apart days-apart})))
 
 (defspec date-geq?-and-date-leq?-equal-dates-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [dt generate-random-datetime]
            (and (date-geq? dt dt)
                 (date-leq? dt dt))))
 
 (defspec date-geq?-test
-         50
+         number-of-test-check-iterations
          (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
            (date-geq? dt-b dt-a)))
 
 (defspec date-leq?-test
-         50
+         number-of-test-check-iterations
          (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
            (date-leq? dt-a dt-b)))
 
 (defspec first-monday-before-datetime-test
-         50
+         number-of-test-check-iterations
          (prop/for-all [monday-dt generate-random-monday-datetime
                         days-to-add (gen/choose 0 6)]
            (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add))]
              (= monday-dt (first-monday-before-datetime later-in-week-dt)))))
 
 (defspec get-consecutive-datetimes-test
-         20
+         number-of-test-check-iterations
          (let [today-at-start-of-day (t/today-at 0 0),
                tomorrow-at-start-of-day (t/plus today-at-start-of-day (t/days 1))]
            (prop/for-all [random-today-dt-a (generate-random-datetime-on-given-date today-at-start-of-day)
@@ -80,13 +82,13 @@
                        (get-consecutive-datetimes random-today-dt-a random-tomorrow-dt)))))))  ; get datetimes from today until tomorrow
 
 (defspec get-consecutive-datetimes-count-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
            (= (inc days-apart)
               (count (get-consecutive-datetimes from-date until-date)))))
 
 (defspec days-spanned-between-datetimes-test
-         50
+         number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
            (= (inc days-apart)
               (days-spanned-between-datetimes from-date until-date))))

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -75,16 +75,10 @@
 
 (defspec get-consecutive-datetimes-test
          number-of-test-check-iterations
-         (let [today-at-start-of-day (t/today-at 0 0),
-               tomorrow-at-start-of-day (t/plus today-at-start-of-day (t/days 1))]
-           (prop/for-all [random-today-dt-a (generate-random-datetime-on-given-date today-at-start-of-day)
-                          random-today-dt-b (generate-random-datetime-on-given-date today-at-start-of-day)
-                          random-today-dt-c (generate-random-datetime-on-given-date today-at-start-of-day)]
-             (let [random-tomorrow-dt (t/plus random-today-dt-c (t/days 1))]
-               (and (= [today-at-start-of-day]
-                       (get-consecutive-datetimes random-today-dt-a random-today-dt-b))  ; get datetimes from today until today
-                    (= [today-at-start-of-day, tomorrow-at-start-of-day]
-                       (get-consecutive-datetimes random-today-dt-a random-tomorrow-dt)))))))  ; get datetimes from today until tomorrow
+         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+             (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date)]
+               (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc days-apart)))
+                  (get-consecutive-datetimes from-date until-date)))))
 
 (defspec get-consecutive-datetimes-count-test
          number-of-test-check-iterations

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -102,6 +102,13 @@
                (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc num-days-apart)))
                   (get-consecutive-datetimes from-date until-date)))))
 
+; Test that each `DateTime` produced by `get-consecutive-datetimes` is at the start of the day
+(defspec get-consecutive-datetimes-start-of-day-test
+         number-of-test-check-iterations
+         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+           (every? #(= 0 (t/hour %) (t/minute %))
+                   (get-consecutive-datetimes dt-a dt-b))))
+
 (defspec days-spanned-between-datetimes-test
          number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -1,0 +1,89 @@
+(ns api.dt-util-test
+  (:require [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test :refer [deftest, testing, is]]
+            [api.dt-util :refer [date-geq?, date-leq?, first-monday-before-datetime,
+                                 days-spanned-between-datetimes, get-consecutive-datetimes]]
+            [clj-time.core :as t]))
+
+(def generate-random-hour (gen/choose 0 23))
+(def generate-random-minute (gen/choose 0 59))
+(def generate-random-datetime
+  (gen/let [hour generate-random-hour,
+            minute generate-random-minute,
+            days-to-add gen/int]
+    (t/plus (t/today-at hour minute)
+            (t/days days-to-add))))
+
+(def generate-random-monday-datetime
+  (gen/let [weeks-to-add gen/int]
+    (t/plus (t/date-time 2018 5 7)  ; May 7 2018 was a Monday
+            (t/weeks weeks-to-add))))
+
+(defn get-later-datetime
+  "Returns a `DateTime` instance `days-to-add` days later than `dt`, at time `hour`:`minute`."
+  [dt days-to-add hour minute]
+  (-> dt
+      t/with-time-at-start-of-day
+      (t/plus (t/days days-to-add)
+              (t/hours hour)
+              (t/minutes minute))))
+
+; Generates a sorted two-element vector of DateTimes
+(def generate-two-random-sorted-datetimes
+  (gen/let [dt-a generate-random-datetime
+            dt-b generate-random-datetime]
+    (sort [dt-a dt-b])))
+
+(defspec date-geq?-and-date-leq?-equal-dates-test
+         10
+         (prop/for-all [dt generate-random-datetime]
+           (and (date-geq? dt dt)
+                (date-leq? dt dt))))
+
+(defspec date-geq?-test
+         50
+         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+           (date-geq? dt-b dt-a)))
+
+(defspec date-leq?-test
+         50
+         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+           (date-leq? dt-a dt-b)))
+
+(defspec first-monday-before-datetime-test
+         50
+         (prop/for-all [monday-dt generate-random-monday-datetime
+                        days-to-add (gen/choose 0 6)]
+           (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add))]
+             (= monday-dt (first-monday-before-datetime later-in-week-dt)))))
+
+(deftest get-consecutive-datetimes-test
+         (testing "Today until today"
+                  (let [dt-a (t/today-at 3 3)
+                        dt-b (t/today-at 2 2)]
+                    (is (= [(t/today-at 0 0)] (get-consecutive-datetimes dt-a dt-b)))))
+         (testing "Today until tomorrow"
+                  (let [dt-a (t/today-at 3 3)
+                        dt-b (get-later-datetime dt-a 1 2 2)]
+                    (is (= [(t/today-at 0 0), (t/plus (t/today-at 0 0) (t/days 1))]
+                           (get-consecutive-datetimes dt-a dt-b))))))
+
+(defspec get-consecutive-datetimes-count-test
+         10
+         (prop/for-all [dt-a generate-random-datetime
+                        days-to-add gen/nat
+                        hour-b (gen/choose 0 23)
+                        minute-b (gen/choose 0 59)]
+           (let [dt-b (get-later-datetime dt-a days-to-add hour-b minute-b)]
+             (= (inc days-to-add) (count (get-consecutive-datetimes dt-a dt-b))))))
+
+(defspec days-spanned-between-datetimes-test
+         50
+         (prop/for-all [dt-a generate-random-datetime
+                        days-to-add gen/nat
+                        hour-b (gen/choose 0 23)
+                        minute-b (gen/choose 0 59)]
+           (let [dt-b (get-later-datetime dt-a days-to-add hour-b minute-b)]
+             (= (inc days-to-add) (days-spanned-between-datetimes dt-a dt-b)))))

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -11,45 +11,45 @@
 ;; Generators
 ;; ---------------------------------------------------------------------------
 
-(def generate-random-hour (gen/choose 0 23))
+(def gen-hour (gen/choose 0 23))
 
-(def generate-random-minute (gen/choose 0 59))
+(def gen-minute (gen/choose 0 59))
 
-(def generate-random-datetime
-  (gen/let [hour generate-random-hour,
-            minute generate-random-minute,
+(def gen-datetime
+  (gen/let [hour gen-hour,
+            minute gen-minute,
             num-days-to-add gen/int]
     (t/plus (t/today-at hour minute)
             (t/days num-days-to-add))))
 
-(def generate-random-monday-datetime
+(def gen-monday-datetime
   (gen/let [num-weeks-to-add gen/int]
     (t/plus (t/date-time 2018 5 7)  ; May 7 2018 was a Monday
             (t/weeks num-weeks-to-add))))
 
-(defn generate-random-datetime-on-given-date
+(defn gen-datetime-on-given-date
   "Returns a generator for a `DateTime` instance on the same date as `dt`, with a random time."
   [dt]
-  (gen/let [hour generate-random-hour,
-            minute generate-random-minute]
+  (gen/let [hour gen-hour,
+            minute gen-minute]
     (-> dt
         t/with-time-at-start-of-day
         (t/plus (t/hours hour) (t/minutes minute)))))
 
 (defn random-datetime-on-given-date
-  "Like `generate-random-datetime-on-given-date`, but returns a `DateTime` instead of a generator for one."
+  "Like `gen-datetime-on-given-date`, but returns a `DateTime` instead of a generator for one."
   [dt]
-  (gen/generate (generate-random-datetime-on-given-date dt)))
+  (gen/generate (gen-datetime-on-given-date dt)))
 
 ; Generates a sorted two-element vector of DateTimes
-(def generate-two-random-sorted-datetimes
-  (gen/let [dt-a generate-random-datetime
-            dt-b generate-random-datetime]
+(def gen-two-sorted-datetimes
+  (gen/let [dt-a gen-datetime
+            dt-b gen-datetime]
     (sort [dt-a dt-b])))
 
 ; Generates two random `DateTime`s, with `until-date` being `num-days-apart` days later than `from-date`. Returns a map of the values.
-(def generate-two-random-datetimes-with-num-days-apart
-  (gen/let [from-date generate-random-datetime,
+(def gen-two-datetimes-with-num-days-apart
+  (gen/let [from-date gen-datetime,
             num-days-apart gen/nat]
     (let [until-date (t/plus (random-datetime-on-given-date from-date)
                              (t/days num-days-apart))]
@@ -60,44 +60,44 @@
 
 (defspec date-geq?-and-date-leq?-equal-dates-test
          number-of-test-check-iterations
-         (prop/for-all [dt generate-random-datetime]
+         (prop/for-all [dt gen-datetime]
            (and (date-geq? dt dt)
                 (date-leq? dt dt))))
 
 (defspec date-geq?-true-test
          number-of-test-check-iterations
-         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+         (prop/for-all [[dt-a dt-b] gen-two-sorted-datetimes]
            (date-geq? dt-b dt-a)))
 
 (defspec date-geq?-false-test
          number-of-test-check-iterations
-         (prop/for-all [dt-a generate-random-datetime
+         (prop/for-all [dt-a gen-datetime
                         num-days-later gen/s-pos-int]
            (let [dt-b (random-datetime-on-given-date (t/plus dt-a (t/days num-days-later)))]
              (not (date-geq? dt-a dt-b)))))
 
 (defspec date-leq?-true-test
          number-of-test-check-iterations
-         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+         (prop/for-all [[dt-a dt-b] gen-two-sorted-datetimes]
            (date-leq? dt-a dt-b)))
 
 (defspec date-leq?-false-test
          number-of-test-check-iterations
-         (prop/for-all [dt-a generate-random-datetime
+         (prop/for-all [dt-a gen-datetime
                         num-days-later gen/s-pos-int]
            (let [dt-b (random-datetime-on-given-date (t/plus dt-a (t/days num-days-later)))]
              (not (date-leq? dt-b dt-a)))))
 
 (defspec first-monday-before-datetime-test
          number-of-test-check-iterations
-         (prop/for-all [monday-dt generate-random-monday-datetime
+         (prop/for-all [monday-dt gen-monday-datetime
                         num-days-later (gen/choose 0 6)]
            (let [later-in-week-dt (t/plus monday-dt (t/days num-days-later))]
              (= monday-dt (first-monday-before-datetime later-in-week-dt)))))
 
 (defspec get-consecutive-datetimes-test
          number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} gen-two-datetimes-with-num-days-apart]
              (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date)]
                (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc num-days-apart)))
                   (get-consecutive-datetimes from-date until-date)))))
@@ -105,19 +105,19 @@
 ; Test that each `DateTime` produced by `get-consecutive-datetimes` is at the start of the day
 (defspec get-consecutive-datetimes-start-of-day-test
          number-of-test-check-iterations
-         (prop/for-all [[dt-a dt-b] generate-two-random-sorted-datetimes]
+         (prop/for-all [[dt-a dt-b] gen-two-sorted-datetimes]
            (every? #(= 0 (t/hour %) (t/minute %))
                    (get-consecutive-datetimes dt-a dt-b))))
 
 ; Test that `get-consecutive-datetimes` produces the correct number of `DateTime`s
 (defspec get-consecutive-datetimes-count-test
          number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} gen-two-datetimes-with-num-days-apart]
            (= (inc num-days-apart)
               (count (get-consecutive-datetimes from-date until-date)))))
 
 (defspec days-spanned-between-datetimes-test
          number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} gen-two-datetimes-with-num-days-apart]
            (= (inc num-days-apart)
               (days-spanned-between-datetimes from-date until-date))))

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -36,6 +36,15 @@
             dt-b generate-random-datetime]
     (sort [dt-a dt-b])))
 
+; Generates two random `DateTime`s, with `until-date` being `days-apart` days later than `from-date`. Returns a map of the values.
+(def generate-two-random-datetimes-with-days-apart
+  (gen/let [from-date generate-random-datetime,
+            days-apart gen/nat,
+            until-date-hour generate-random-hour,
+            until-date-minute generate-random-minute]
+    (let [until-date (get-later-datetime from-date days-apart until-date-hour until-date-minute)]
+      {:from-date from-date, :until-date until-date, :days-apart days-apart})))
+
 (defspec date-geq?-and-date-leq?-equal-dates-test
          10
          (prop/for-all [dt generate-random-datetime]
@@ -72,18 +81,12 @@
 
 (defspec get-consecutive-datetimes-count-test
          10
-         (prop/for-all [dt-a generate-random-datetime
-                        days-to-add gen/nat
-                        hour-b (gen/choose 0 23)
-                        minute-b (gen/choose 0 59)]
-           (let [dt-b (get-later-datetime dt-a days-to-add hour-b minute-b)]
-             (= (inc days-to-add) (count (get-consecutive-datetimes dt-a dt-b))))))
+         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+           (= (inc days-apart)
+              (count (get-consecutive-datetimes from-date until-date)))))
 
 (defspec days-spanned-between-datetimes-test
          50
-         (prop/for-all [dt-a generate-random-datetime
-                        days-to-add gen/nat
-                        hour-b (gen/choose 0 23)
-                        minute-b (gen/choose 0 59)]
-           (let [dt-b (get-later-datetime dt-a days-to-add hour-b minute-b)]
-             (= (inc days-to-add) (days-spanned-between-datetimes dt-a dt-b)))))
+         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+           (= (inc days-apart)
+              (days-spanned-between-datetimes from-date until-date))))

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -13,14 +13,14 @@
 (def generate-random-datetime
   (gen/let [hour generate-random-hour,
             minute generate-random-minute,
-            days-to-add gen/int]
+            num-days-to-add gen/int]
     (t/plus (t/today-at hour minute)
-            (t/days days-to-add))))
+            (t/days num-days-to-add))))
 
 (def generate-random-monday-datetime
-  (gen/let [weeks-to-add gen/int]
+  (gen/let [num-weeks-to-add gen/int]
     (t/plus (t/date-time 2018 5 7)  ; May 7 2018 was a Monday
-            (t/weeks weeks-to-add))))
+            (t/weeks num-weeks-to-add))))
 
 (defn generate-random-datetime-on-given-date
   "Returns a generator for a `DateTime` instance on the same date as `dt`, with a random time."
@@ -42,13 +42,13 @@
             dt-b generate-random-datetime]
     (sort [dt-a dt-b])))
 
-; Generates two random `DateTime`s, with `until-date` being `days-apart` days later than `from-date`. Returns a map of the values.
-(def generate-two-random-datetimes-with-days-apart
+; Generates two random `DateTime`s, with `until-date` being `num-days-apart` days later than `from-date`. Returns a map of the values.
+(def generate-two-random-datetimes-with-num-days-apart
   (gen/let [from-date generate-random-datetime,
-            days-apart gen/nat]
+            num-days-apart gen/nat]
     (let [until-date (t/plus (random-datetime-on-given-date from-date)
-                             (t/days days-apart))]
-      {:from-date from-date, :until-date until-date, :days-apart days-apart})))
+                             (t/days num-days-apart))]
+      {:from-date from-date, :until-date until-date, :num-days-apart num-days-apart})))
 
 (defspec date-geq?-and-date-leq?-equal-dates-test
          number-of-test-check-iterations
@@ -69,19 +69,19 @@
 (defspec first-monday-before-datetime-test
          number-of-test-check-iterations
          (prop/for-all [monday-dt generate-random-monday-datetime
-                        days-to-add (gen/choose 0 6)]
-           (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add))]
+                        num-days-later (gen/choose 0 6)]
+           (let [later-in-week-dt (t/plus monday-dt (t/days num-days-later))]
              (= monday-dt (first-monday-before-datetime later-in-week-dt)))))
 
 (defspec get-consecutive-datetimes-test
          number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
              (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date)]
-               (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc days-apart)))
+               (= (map #(t/plus from-date-at-start-of-day (t/days %)) (range (inc num-days-apart)))
                   (get-consecutive-datetimes from-date until-date)))))
 
 (defspec days-spanned-between-datetimes-test
          number-of-test-check-iterations
-         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
-           (= (inc days-apart)
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
+           (= (inc num-days-apart)
               (days-spanned-between-datetimes from-date until-date))))

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -31,6 +31,11 @@
         t/with-time-at-start-of-day
         (t/plus (t/hours hour) (t/minutes minute)))))
 
+(defn random-datetime-on-given-date
+  "Like `generate-random-datetime-on-given-date`, but returns a `DateTime` instead of a generator for one."
+  [dt]
+  (gen/generate (generate-random-datetime-on-given-date dt)))
+
 ; Generates a sorted two-element vector of DateTimes
 (def generate-two-random-sorted-datetimes
   (gen/let [dt-a generate-random-datetime
@@ -41,7 +46,7 @@
 (def generate-two-random-datetimes-with-days-apart
   (gen/let [from-date generate-random-datetime,
             days-apart gen/nat]
-    (let [until-date (t/plus (gen/generate (generate-random-datetime-on-given-date from-date))
+    (let [until-date (t/plus (random-datetime-on-given-date from-date)
                              (t/days days-apart))]
       {:from-date from-date, :until-date until-date, :days-apart days-apart})))
 

--- a/api/test/api/dt_util_test.clj
+++ b/api/test/api/dt_util_test.clj
@@ -109,6 +109,13 @@
            (every? #(= 0 (t/hour %) (t/minute %))
                    (get-consecutive-datetimes dt-a dt-b))))
 
+; Test that `get-consecutive-datetimes` produces the correct number of `DateTime`s
+(defspec get-consecutive-datetimes-count-test
+         number-of-test-check-iterations
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]
+           (= (inc num-days-apart)
+              (count (get-consecutive-datetimes from-date until-date)))))
+
 (defspec days-spanned-between-datetimes-test
          number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date num-days-apart]} generate-two-random-datetimes-with-num-days-apart]

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -9,10 +9,14 @@
 
 (def number-of-test-check-iterations 30)
 
+(defn create-specific-day-of-week-frequency
+  "Creates a `specific_day_of_week_frequency` from a vector of numbers corresponding to Monday to Sunday amounts."
+  [week-amount-vector]
+  (assoc (zipmap [:monday :tuesday :wednesday :thursday :friday :saturday :sunday] week-amount-vector)
+         :type_name "specific_day_of_week_frequency"))
+
 (def generate-random-specific-day-of-week-frequency
-  (gen/hash-map :type_name (gen/return "specific_day_of_week_frequency"),
-                :monday gen/nat, :tuesday gen/nat, :wednesday gen/nat, :thursday gen/nat,
-                :friday gen/nat, :saturday gen/nat, :sunday gen/nat))
+  (gen/fmap create-specific-day-of-week-frequency (gen/vector gen/nat 7)))
 
 (def generate-random-total-week-frequency
   (gen/hash-map :type_name (gen/return "total_week_frequency"),
@@ -94,9 +98,7 @@
                         monday-dt dt-util-test/generate-random-monday-datetime,
                         days-to-add (gen/choose 0 6)]
            (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
-                 specific-day-of-week-frequency (assoc (zipmap [:monday :tuesday :wednesday :thursday :friday :saturday :sunday]
-                                                               week-amount-vector)
-                                                       :type_name "specific_day_of_week_frequency")]
+                 specific-day-of-week-frequency (create-specific-day-of-week-frequency week-amount-vector)]
              (= (nth week-amount-vector days-to-add)
                 (freq-stats-util/get-habit-goal-amount-for-datetime later-in-week-dt specific-day-of-week-frequency)))))
 

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -117,7 +117,7 @@
                  sorted-habit-data [(random-habit-day-record {:gen-date (gen/return later-in-week-dt)})]]
              (and (= monday-dt (freq-stats-util/get-habit-start-date sorted-habit-data total-week-frequency))
                   (= later-in-week-dt (freq-stats-util/get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
-                        (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency))))))
+                                      (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency))))))
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -169,7 +169,7 @@
                         days-to-add gen/int]
            (let [habit-goal-fragment (random-habit-goal-fragment {:gen-start-date (gen/return from-date)
                                                                   :gen-end-date (gen/return until-date)}),
-                 datetime (t/plus (gen/generate (dt-util-test/generate-random-datetime-on-given-date from-date))
+                 datetime (t/plus (dt-util-test/random-datetime-on-given-date from-date)
                                   (t/days days-to-add))]
              (= (<= 0 days-to-add days-apart)
                 (freq-stats-util/during-habit-goal-fragment? datetime habit-goal-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -119,14 +119,12 @@
 (defspec get-habit-start-date-other-frequencies-test
          number-of-test-check-iterations
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
-                        every-x-days-frequency generate-random-every-x-days-frequency,
-                        monday-dt dt-util-test/generate-random-monday-datetime]
-           (let [same-week-sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector (gen/fmap #(t/plus monday-dt (t/days %))
-                                                                                                     (gen/choose 0 6))))))
-                 same-week-sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) same-week-sorted-datetimes)]
-             (= (first same-week-sorted-datetimes)
-                (freq-stats-util/get-habit-start-date same-week-sorted-habit-data specific-day-of-week-frequency)
-                (freq-stats-util/get-habit-start-date same-week-sorted-habit-data every-x-days-frequency)))))
+                        every-x-days-frequency generate-random-every-x-days-frequency]
+           (let [sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector dt-util-test/generate-random-datetime))))
+                 sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) sorted-datetimes)]
+             (= (first sorted-datetimes)
+                (freq-stats-util/get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
+                (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency)))))
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -175,9 +175,9 @@
 (defspec get-habit-data-during-fragment-test
          number-of-test-check-iterations
          (prop/for-all [days-to-subtract gen/s-pos-int,
-                        days-to-add gen/s-pos-int]
-           (let [habit-goal-fragment (random-habit-goal-fragment {}),
-                 start-date (:start-date habit-goal-fragment),
+                        days-to-add gen/s-pos-int,
+                        habit-goal-fragment (generate-random-habit-goal-fragment {})]
+           (let [start-date (:start-date habit-goal-fragment),
                  end-date (:end-date habit-goal-fragment),
                  too-early-dt (t/minus start-date (t/days days-to-subtract)),
                  outside-range-record-a (random-habit-day-record {:gen-date (gen/return too-early-dt)}),

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -10,6 +10,9 @@
 
 (def number-of-test-check-iterations 30)
 
+;; Generators
+;; ---------------------------------------------------------------------------
+
 (defn create-specific-day-of-week-frequency
   "Creates a `specific_day_of_week_frequency` from a vector of numbers corresponding to Monday to Sunday amounts."
   [week-amount-vector]
@@ -76,6 +79,9 @@
   Args should still be generators, as in `generate-random-habit-goal-fragment`."
   [args]
   (gen/generate (generate-random-habit-goal-fragment args)))
+
+;; Tests
+;; ---------------------------------------------------------------------------
 
 (defspec get-habit-goal-fragment-length-specific-day-of-week-frequency-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -84,15 +84,14 @@
 
 (defspec get-habit-goal-amount-for-datetime-specific-day-of-week-frequency-test
          number-of-test-check-iterations
-         (prop/for-all [freq generate-random-specific-day-of-week-frequency,
-                        dt dt-util-test/generate-random-monday-datetime]
-           (and (= (:monday freq) (freq-stats-util/get-habit-goal-amount-for-datetime dt freq))
-                (= (:tuesday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 1)) freq))
-                (= (:wednesday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 2)) freq))
-                (= (:thursday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 3)) freq))
-                (= (:friday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 4)) freq))
-                (= (:saturday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 5)) freq))
-                (= (:sunday freq) (freq-stats-util/get-habit-goal-amount-for-datetime (t/plus dt (t/days 6)) freq)))))
+         (prop/for-all [week-amount-vector (gen/vector gen/nat 7),
+                        monday-dt dt-util-test/generate-random-monday-datetime,
+                        days-to-add (gen/choose 0 6)]
+           (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
+                 freq (assoc (zipmap [:monday :tuesday :wednesday :thursday :friday :saturday :sunday] week-amount-vector)
+                             :type_name "specific_day_of_week_frequency")]
+             (= (nth week-amount-vector days-to-add)
+                (freq-stats-util/get-habit-goal-amount-for-datetime later-in-week-dt freq)))))
 
 (defspec get-habit-goal-amount-for-datetime-total-week-frequency-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -35,6 +35,12 @@
                 :date generate-random-datetime,
                 :amount gen/nat))
 
+(defn random-habit-goal-fragment-with-given-dates
+  "Creates a habit goal fragment with specified `start-date` and `end-date`, and random `total-done` and `successful` fields."
+  [start-date end-date]
+  (gen/generate (gen/let [total-done gen/nat, successful gen/boolean]
+                  {:start-date start-date, :end-date end-date, :total-done total-done, :successful successful})))
+
 (defspec get-habit-goal-fragment-length-specific-day-of-week-frequency-test
          10
          (prop/for-all [freq generate-random-specific-day-of-week-frequency]
@@ -123,10 +129,8 @@
 
 (defspec span-of-habit-goal-fragment-test
          20
-         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
-                        total-done gen/nat,
-                        successful gen/boolean]
-           (let [habit-goal-fragment {:start-date from-date, :end-date until-date, :total-done total-done, :successful successful}]
+         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+           (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date)]
              (= (inc days-apart)
                 (span-of-habit-goal-fragment habit-goal-fragment)))))
 
@@ -135,10 +139,8 @@
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
                         days-to-add gen/int,
                         datetime-hour generate-random-hour,
-                        datetime-minute generate-random-minute,
-                        total-done gen/nat,
-                        successful gen/boolean]
-           (let [habit-goal-fragment {:start-date from-date, :end-date until-date, :total-done total-done, :successful successful},
+                        datetime-minute generate-random-minute]
+           (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date),
                  datetime (get-later-datetime from-date days-to-add datetime-hour datetime-minute)]
              (= (<= 0 days-to-add days-apart)
                 (during-habit-goal-fragment? datetime habit-goal-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -367,9 +367,10 @@
          number-of-test-check-iterations
          (prop/for-all [habit-frequency-stats (generate-random-habit-frequency-stats {}),
                         every-x-days-frequency generate-random-every-x-days-frequency,
-                        current-fragment-start-date dt-util-test/generate-random-datetime,
-                        num-days-later (gen/choose 0 6)]
-           (let [current-fragment-end-date (t/plus current-fragment-start-date (t/days num-days-later)),
+                        current-fragment-start-date dt-util-test/generate-random-datetime]
+           (let [fragment-length (:days every-x-days-frequency),
+                 num-days-later (gen/generate (gen/choose 0 (dec fragment-length)))
+                 current-fragment-end-date (t/plus current-fragment-start-date (t/days num-days-later)),
                  failed-current-fragment (random-habit-goal-fragment {:gen-start-date (gen/return current-fragment-start-date),
                                                                       :gen-end-date (gen/return current-fragment-end-date),
                                                                       :gen-successful (gen/return false)}),
@@ -379,7 +380,7 @@
                     (update :total_done + total-done)
                     (assoc :current_fragment_total total-done)
                     (assoc :current_fragment_goal (:times every-x-days-frequency))
-                    (assoc :current_fragment_days_left (- (:days every-x-days-frequency) (inc num-days-later))))
+                    (assoc :current_fragment_days_left (- fragment-length (inc num-days-later))))
                 (freq-stats-util/update-freq-stats-with-current-fragment habit-frequency-stats
                                                                          failed-current-fragment
                                                                          every-x-days-frequency

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -6,9 +6,10 @@
             [api.dt-util :refer [days-spanned-between-datetimes]]
             [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
                                          get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
-                                         span-of-habit-goal-fragment]]
+                                         span-of-habit-goal-fragment, during-habit-goal-fragment?]]
             [api.dt-util-test :refer [generate-random-datetime, generate-random-monday-datetime, generate-two-random-sorted-datetimes,
-                                      generate-two-random-datetimes-with-days-apart]])
+                                      generate-two-random-datetimes-with-days-apart, generate-random-hour, generate-random-minute,
+                                      get-later-datetime]])
   (:import org.bson.types.ObjectId))
 
 (def generate-random-specific-day-of-week-frequency
@@ -128,3 +129,16 @@
            (let [habit-goal-fragment {:start-date from-date, :end-date until-date, :total-done total-done, :successful successful}]
              (= (inc days-apart)
                 (span-of-habit-goal-fragment habit-goal-fragment)))))
+
+(defspec during-habit-goal-fragment?-test
+         20
+         (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
+                        days-to-add gen/int,
+                        datetime-hour generate-random-hour,
+                        datetime-minute generate-random-minute,
+                        total-done gen/nat,
+                        successful gen/boolean]
+           (let [habit-goal-fragment {:start-date from-date, :end-date until-date, :total-done total-done, :successful successful},
+                 datetime (get-later-datetime from-date days-to-add datetime-hour datetime-minute)]
+             (= (<= 0 days-to-add days-apart)
+                (during-habit-goal-fragment? datetime habit-goal-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -239,6 +239,28 @@
              (= [within-range-record-a, within-range-record-b]
                 (freq-stats-util/get-habit-data-during-fragment habit-data habit-goal-fragment)))))
 
+(defspec get-habit-data-during-fragment-within-range-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {})]
+           (let [start-date (:start-date habit-goal-fragment),
+                 end-date (:end-date habit-goal-fragment),
+                 generate-within-range-dt (gen/fmap #(t/plus start-date (t/days %))
+                                                    (gen/choose 0 (dec (dt-util/days-spanned-between-datetimes start-date end-date)))),
+                 within-range-data (gen/generate (gen/vector (generate-random-habit-day-record {:gen-date generate-within-range-dt})))]
+             (= within-range-data
+                (freq-stats-util/get-habit-data-during-fragment within-range-data habit-goal-fragment)))))
+
+(defspec get-habit-data-during-fragment-outside-range-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {})]
+           (let [start-date (:start-date habit-goal-fragment),
+                 end-date (:end-date habit-goal-fragment),
+                 generate-outside-range-dt (gen/one-of [(gen/fmap #(t/minus start-date (t/days %)) gen/s-pos-int),
+                                                        (gen/fmap #(t/plus end-date (t/days %)) gen/s-pos-int)]),
+                 outside-range-data (gen/generate (gen/vector (generate-random-habit-day-record {:gen-date generate-outside-range-dt})))]
+             (= []
+                (freq-stats-util/get-habit-data-during-fragment outside-range-data habit-goal-fragment)))))
+
 (defspec evaluate-habit-goal-fragment-total-done-test
          number-of-test-check-iterations
          (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {}),

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -157,6 +157,20 @@
              (= [first-week-datetimes, remaining-datetimes]
                 (freq-stats-util/partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))))
 
+(defspec partition-datetimes-based-on-habit-goal-every-x-days-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [times gen/nat,
+                        from-date dt-util-test/generate-random-datetime]
+           (let [every-x-days-frequency {:type_name "every_x_days_frequency",
+                                         :times times,
+                                         :days 12}
+                 until-date (dt-util-test/random-datetime-on-given-date (t/plus from-date (t/days 18))),
+                 from-date-at-start-of-day (t/with-time-at-start-of-day from-date),
+                 first-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 12)),
+                 remaining-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 12 19))]
+             (= [first-datetimes, remaining-datetimes]
+                (freq-stats-util/partition-datetimes-based-on-habit-goal every-x-days-frequency from-date until-date)))))
+
 (defspec create-habit-goal-fragment-test
          number-of-test-check-iterations
          (prop/for-all [[start-date end-date :as datetimes] dt-util-test/generate-two-random-sorted-datetimes

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -186,14 +186,19 @@
              (= [first-fragment-dates, remaining-fragment-dates]
                 (freq-stats-util/partition-datetimes-based-on-habit-goal freq from-date until-date)))))
 
-(defspec create-habit-goal-fragment-test
+(defspec create-habit-goal-fragment-single-date-fragment-test
          number-of-test-check-iterations
-         (prop/for-all [[start-date end-date :as datetimes] dt-util-test/generate-two-random-sorted-datetimes
-                        single-date dt-util-test/generate-random-datetime]
-           (and (= {:start-date start-date, :end-date end-date, :total-done 0, :successful false}
-                   (freq-stats-util/create-habit-goal-fragment datetimes))
-                (= {:start-date single-date, :end-date single-date, :total-done 0, :successful false}
-                   (freq-stats-util/create-habit-goal-fragment [single-date])))))
+         (prop/for-all [single-date dt-util-test/generate-random-datetime]
+           (= {:start-date single-date, :end-date single-date, :total-done 0, :successful false}
+              (freq-stats-util/create-habit-goal-fragment [single-date]))))
+
+(defspec create-habit-goal-fragment-multiple-date-fragment-test
+         number-of-test-check-iterations
+         (prop/for-all [{:keys [from-date until-date num-days-apart]} dt-util-test/generate-two-random-datetimes-with-num-days-apart]
+           (let [middle-dates (gen/generate (gen/vector (gen/fmap #(t/plus from-date (t/days %)) (gen/choose 0 num-days-apart)))),
+                 datetimes (cons from-date (conj middle-dates until-date))]
+             (= {:start-date from-date, :end-date until-date, :total-done 0, :successful false}
+                (freq-stats-util/create-habit-goal-fragment datetimes)))))
 
 (defspec span-of-habit-goal-fragment-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -37,9 +37,12 @@
                               :amount gen/nat)))
 
 (defn random-habit-goal-fragment-with-given-dates
-  "Creates a habit goal fragment with specified `start-date` and `end-date`, and random `total-done` and `successful` fields."
+  "Creates a habit goal fragment with specified `start-date` and `end-date` but at random times, and random other fields."
   [start-date end-date]
-  (gen/generate (gen/let [total-done gen/nat, successful gen/boolean]
+  (gen/generate (gen/let [start-date (generate-random-datetime-on-given-date start-date),
+                          end-date (generate-random-datetime-on-given-date end-date),
+                          total-done gen/nat,
+                          successful gen/boolean]
                   {:start-date start-date, :end-date end-date, :total-done total-done, :successful successful})))
 
 (defspec get-habit-goal-fragment-length-specific-day-of-week-frequency-test

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -38,6 +38,12 @@
                 :date gen-date,
                 :amount gen-amount))
 
+(defn random-habit-day-record
+  "Like `generate-random-habit-day-record`, but returns a `habit_day_record` instead of a generator for one.
+  Args should still be generators, as in `generate-random-habit-day-record`."
+  [args]
+  (gen/generate (generate-random-habit-day-record args)))
+
 (defn generate-random-habit-goal-fragment
   "Generates a habit goal fragment, with each field created by its supplied generator, or randomly generated if not supplied.
   If either `gen-start-date` or `gen-end-date` is not supplied, generates both dates and makes sure `start-date` comes before `end-date`."
@@ -108,7 +114,7 @@
                         monday-dt dt-util-test/generate-random-monday-datetime,
                         days-to-add (gen/choose 0 6)]
            (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
-                 sorted-habit-data [(gen/generate (generate-random-habit-day-record {:gen-date (gen/return later-in-week-dt)}))]]
+                 sorted-habit-data [(random-habit-day-record {:gen-date (gen/return later-in-week-dt)})]]
              (and (= monday-dt (freq-stats-util/get-habit-start-date sorted-habit-data total-week-frequency))
                   (= later-in-week-dt (freq-stats-util/get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
                         (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency))))))
@@ -174,11 +180,11 @@
                  start-date (:start-date habit-goal-fragment),
                  end-date (:end-date habit-goal-fragment),
                  too-early-dt (t/minus start-date (t/days days-to-subtract)),
-                 outside-range-record-a (gen/generate (generate-random-habit-day-record {:gen-date (gen/return too-early-dt)})),
-                 within-range-record-a (gen/generate (generate-random-habit-day-record {:gen-date (gen/return start-date)})),
-                 within-range-record-b (gen/generate (generate-random-habit-day-record {:gen-date (gen/return end-date)})),
+                 outside-range-record-a (random-habit-day-record {:gen-date (gen/return too-early-dt)}),
+                 within-range-record-a (random-habit-day-record {:gen-date (gen/return start-date)}),
+                 within-range-record-b (random-habit-day-record {:gen-date (gen/return end-date)}),
                  too-late-dt (t/plus end-date (t/days days-to-add)),
-                 outside-range-record-b (gen/generate (generate-random-habit-day-record {:gen-date (gen/return too-late-dt)})),
+                 outside-range-record-b (random-habit-day-record {:gen-date (gen/return too-late-dt)}),
                  habit-data [outside-range-record-a,
                              within-range-record-a,
                              within-range-record-b,

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -207,10 +207,18 @@
              (= (update habit-goal-fragment :total-done + (apply + amounts))
                 (freq-stats-util/evaluate-habit-goal-fragment-total-done habit-goal-fragment habit-data-during-fragment)))))
 
-(defspec evaluate-habit-goal-fragment-successful-test
+(defspec evaluate-habit-goal-fragment-successful-bad-habit-total-week-frequency-test
          number-of-test-check-iterations
          (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {}),
                         total-week-frequency generate-random-total-week-frequency]
            (let [habit-type "bad_habit"]
              (= (assoc habit-goal-fragment :successful (<= (:total-done habit-goal-fragment) (:week total-week-frequency)))
                 (freq-stats-util/evaluate-habit-goal-fragment-successful habit-goal-fragment habit-type total-week-frequency)))))
+
+(defspec evaluate-habit-goal-fragment-successful-good-habit-every-x-days-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {}),
+                        every-x-days-frequency generate-random-every-x-days-frequency]
+           (let [habit-type "good_habit"]
+             (= (assoc habit-goal-fragment :successful (>= (:total-done habit-goal-fragment) (:times every-x-days-frequency)))
+                (freq-stats-util/evaluate-habit-goal-fragment-successful habit-goal-fragment habit-type every-x-days-frequency)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -3,7 +3,6 @@
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clj-time.core :as t]
-            [api.dt-util :refer [days-spanned-between-datetimes]]
             [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
                                          get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
                                          span-of-habit-goal-fragment, during-habit-goal-fragment?, get-habit-data-during-fragment]]
@@ -108,8 +107,8 @@
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
-                        [from-date until-date] generate-two-random-sorted-datetimes]
-           (let [total-span (days-spanned-between-datetimes from-date until-date)]
+                        {:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
+           (let [total-span (inc days-apart)]
              (and (= total-span (count (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
                   (== (Math/ceil (/ total-span 7))
                       (count (partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -493,3 +493,18 @@
                 (:total_done (freq-stats-util/compute-freq-stats-from-habit-goal-fragments habit-goal-fragments
                                                                                            habit
                                                                                            freq))))))
+
+(defspec get-freq-stats-for-habit-total-done-test
+         number-of-test-check-iterations
+         (prop/for-all [current-date dt-util-test/generate-random-datetime,
+                        habit generate-random-habit]
+           (let [generate-random-dt-before-current-date (gen/fmap #(t/minus current-date (t/days %)) gen/nat),
+                 other-habits-data (gen/generate (gen/vector (generate-random-habit-day-record {:gen-habit-id (gen/such-that #(not= % (:_id habit))
+                                                                                                                             generate-random-ID),
+                                                                                                :gen-date generate-random-dt-before-current-date}))),
+                 this-habit-data (gen/generate (gen/vector (generate-random-habit-day-record {:gen-habit-id (gen/return (:_id habit)),
+                                                                                              :gen-date generate-random-dt-before-current-date}))),
+                 all-habit-data-until-current-date (concat other-habits-data this-habit-data),
+                 this-habit-total-done (reduce #(+ %1 (:amount %2)) 0 this-habit-data)]
+             (= this-habit-total-done
+                (:total_done (freq-stats-util/get-freq-stats-for-habit habit all-habit-data-until-current-date current-date))))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -385,3 +385,26 @@
                                                                          failed-current-fragment
                                                                          every-x-days-frequency
                                                                          habit-type)))))
+
+(defspec update-freq-stats-with-current-fragment-bad-habit-failed-fragment-specific-day-of-week-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-frequency-stats (generate-random-habit-frequency-stats {}),
+                        specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
+                        current-fragment-date dt-util-test/generate-random-datetime]
+           (let [failed-current-fragment (random-habit-goal-fragment {:gen-start-date (gen/return current-fragment-date),
+                                                                      :gen-end-date (gen/return current-fragment-date),
+                                                                      :gen-successful (gen/return false)}),
+                 habit-type "bad_habit",
+                 total-done (:total-done failed-current-fragment)]
+             (= (-> habit-frequency-stats
+                    (update :total_fragments inc)
+                    (update :total_done + total-done)
+                    (assoc :current_fragment_streak 0)
+                    (assoc :current_fragment_total total-done)
+                    (assoc :current_fragment_goal (freq-stats-util/get-habit-goal-amount-for-datetime current-fragment-date
+                                                                                                      specific-day-of-week-frequency))
+                    (assoc :current_fragment_days_left 0))
+                (freq-stats-util/update-freq-stats-with-current-fragment habit-frequency-stats
+                                                                         failed-current-fragment
+                                                                         specific-day-of-week-frequency
+                                                                         habit-type)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -106,7 +106,8 @@
                         every-x-days-frequency generate-random-every-x-days-frequency,
                         {:keys [from-date until-date days-apart]} dt-util-test/generate-two-random-datetimes-with-days-apart]
            (let [total-span (inc days-apart)]
-             (and (= total-span (count (freq-stats-util/partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
+             (and (= total-span
+                     (count (freq-stats-util/partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
                   (== (Math/ceil (/ total-span 7))
                       (count (freq-stats-util/partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))
                   (== (Math/ceil (/ total-span (:days every-x-days-frequency)))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -149,8 +149,8 @@
          number-of-test-check-iterations
          (prop/for-all [total-week-frequency generate-random-total-week-frequency,
                         monday-dt dt-util-test/generate-random-monday-datetime]
-           (let [same-week-sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector (gen/fmap #(t/plus monday-dt (t/days %))
-                                                                                                     (gen/choose 0 6))))))
+           (let [generate-same-week-datetime (gen/fmap #(t/plus monday-dt (t/days %)) (gen/choose 0 6))
+                 same-week-sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector generate-same-week-datetime))))
                  same-week-sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) same-week-sorted-datetimes)]
              (= monday-dt
                 (freq-stats-util/get-habit-start-date same-week-sorted-habit-data total-week-frequency)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -235,9 +235,9 @@
                         num-days-later gen/nat,
                         week-amount-vector (gen/vector gen/nat 7)]
            (let [specific-day-of-week-frequency (create-specific-day-of-week-frequency week-amount-vector),
+                 habit-type "bad_habit",
                  current-date (t/plus habit-start-date (t/days num-days-later)),
                  habit-record-dates (dt-util/get-consecutive-datetimes habit-start-date current-date),
-                 habit-type "bad_habit",
                  habit-record-amounts (gen/generate (gen/vector gen/nat (inc num-days-later))),
                  habit-record-days-of-week (map t/day-of-week habit-record-dates),
                  sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %1)

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -8,8 +8,7 @@
                                          get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
                                          span-of-habit-goal-fragment, during-habit-goal-fragment?]]
             [api.dt-util-test :refer [generate-random-datetime, generate-random-monday-datetime, generate-two-random-sorted-datetimes,
-                                      generate-two-random-datetimes-with-days-apart, generate-random-hour, generate-random-minute,
-                                      get-later-datetime]])
+                                      generate-two-random-datetimes-with-days-apart, generate-random-datetime-d-days-later]])
   (:import org.bson.types.ObjectId))
 
 (def generate-random-specific-day-of-week-frequency
@@ -137,10 +136,8 @@
 (defspec during-habit-goal-fragment?-test
          20
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
-                        days-to-add gen/int,
-                        datetime-hour generate-random-hour,
-                        datetime-minute generate-random-minute]
+                        days-to-add gen/int]
            (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date),
-                 datetime (get-later-datetime from-date days-to-add datetime-hour datetime-minute)]
+                 datetime (gen/generate (generate-random-datetime-d-days-later from-date days-to-add))]
              (= (<= 0 days-to-add days-apart)
                 (during-habit-goal-fragment? datetime habit-goal-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -1,0 +1,119 @@
+(ns api.freq-stats-util-test
+  (:require [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clj-time.core :as t]
+            [api.dt-util :refer [days-spanned-between-datetimes]]
+            [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
+                                         get-habit-start-date, partition-datetimes-based-on-habit-goal]]
+            [api.dt-util-test :refer [generate-random-datetime, generate-random-hour, generate-random-minute, get-later-datetime,
+                                      generate-random-monday-datetime]])
+  (:import org.bson.types.ObjectId))
+
+(def generate-random-specific-day-of-week-frequency
+  (gen/hash-map :type_name (gen/return "specific_day_of_week_frequency"),
+                :monday gen/nat, :tuesday gen/nat, :wednesday gen/nat, :thursday gen/nat,
+                :friday gen/nat, :saturday gen/nat, :sunday gen/nat))
+
+(def generate-random-total-week-frequency
+  (gen/hash-map :type_name (gen/return "total_week_frequency"),
+                :week gen/nat))
+
+(def generate-random-every-x-days-frequency
+  (gen/hash-map :type_name (gen/return "every_x_days_frequency"),
+                :times gen/nat, :days gen/s-pos-int))
+
+; Generates a random ObjectId. `(gen/return (ObjectId.))` always returns the same ID, this avoids that.
+(def generate-random-ID
+  (gen/fmap (fn [_] (ObjectId.)) gen/int))
+
+(def generate-random-habit-day-record
+  (gen/hash-map :_id generate-random-ID,
+                :habit_id generate-random-ID,
+                :date generate-random-datetime,
+                :amount gen/nat))
+
+(defspec get-habit-goal-fragment-length-specific-day-of-week-frequency-test
+         10
+         (prop/for-all [freq generate-random-specific-day-of-week-frequency]
+           (= 1 (get-habit-goal-fragment-length freq))))
+
+(defspec get-habit-goal-fragment-length-total-week-frequency-test
+         10
+         (prop/for-all [freq generate-random-total-week-frequency]
+           (= 7 (get-habit-goal-fragment-length freq))))
+
+(defspec get-habit-goal-fragment-length-every-x-days-frequency-test
+         10
+         (prop/for-all [freq generate-random-every-x-days-frequency]
+           (= (:days freq) (get-habit-goal-fragment-length freq))))
+
+(defspec get-habit-goal-amount-for-datetime-specific-day-of-week-frequency-test
+         10
+         (prop/for-all [freq generate-random-specific-day-of-week-frequency,
+                        dt generate-random-monday-datetime]
+           (and (= (:monday freq) (get-habit-goal-amount-for-datetime dt freq))
+                (= (:tuesday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 1)) freq))
+                (= (:wednesday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 2)) freq))
+                (= (:thursday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 3)) freq))
+                (= (:friday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 4)) freq))
+                (= (:saturday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 5)) freq))
+                (= (:sunday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 6)) freq)))))
+
+(defspec get-habit-goal-amount-for-datetime-total-week-frequency-test
+         10
+         (prop/for-all [freq generate-random-total-week-frequency,
+                        dt generate-random-datetime]
+           (= (:week freq) (get-habit-goal-amount-for-datetime dt freq))))
+
+(defspec get-habit-goal-amount-for-datetime-every-x-days-frequency-test
+         10
+         (prop/for-all [freq generate-random-every-x-days-frequency,
+                        dt generate-random-datetime]
+           (= (:times freq) (get-habit-goal-amount-for-datetime dt freq))))
+
+(defspec get-habit-start-date-test
+         50
+         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
+                        total-week-frequency generate-random-total-week-frequency,
+                        every-x-days-frequency generate-random-every-x-days-frequency,
+                        habit-day-record generate-random-habit-day-record,
+                        monday-dt generate-random-monday-datetime,
+                        days-to-add (gen/choose 0 6)]
+           (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
+                 sorted-habit-data [(assoc habit-day-record :date later-in-week-dt)]]
+             (and (= monday-dt (get-habit-start-date sorted-habit-data total-week-frequency))
+                  (= later-in-week-dt (get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
+                        (get-habit-start-date sorted-habit-data every-x-days-frequency))))))
+
+(defspec partition-datetimes-based-on-habit-goal-count-test
+         20
+         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
+                        total-week-frequency generate-random-total-week-frequency,
+                        every-x-days-frequency generate-random-every-x-days-frequency,
+                        from-date generate-random-datetime,
+                        days-to-add gen/nat,
+                        until-date-hour generate-random-hour,
+                        until-date-minute generate-random-minute]
+           (let [until-date (get-later-datetime from-date days-to-add until-date-hour until-date-minute)
+                 total-span (days-spanned-between-datetimes from-date until-date)]
+             (and (= total-span (count (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
+                  (== (Math/ceil (/ total-span 7))
+                      (count (partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))
+                  (== (Math/ceil (/ total-span (:days every-x-days-frequency)))
+                      (count (partition-datetimes-based-on-habit-goal every-x-days-frequency from-date until-date)))))))
+
+(defspec partition-datetimes-based-on-habit-goal-specific-day-of-week-frequency-test
+         20
+         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
+                        from-date generate-random-datetime,
+                        days-to-add gen/nat,
+                        until-date-hour generate-random-hour,
+                        until-date-minute generate-random-minute]
+           (let [until-date (get-later-datetime from-date days-to-add until-date-hour until-date-minute)]
+             (= (map #(-> from-date
+                          t/with-time-at-start-of-day
+                          (t/plus (t/days %))
+                          vector)
+                     (range (inc days-to-add)))
+                (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -5,9 +5,9 @@
             [clj-time.core :as t]
             [api.dt-util :refer [days-spanned-between-datetimes]]
             [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
-                                         get-habit-start-date, partition-datetimes-based-on-habit-goal]]
+                                         get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment]]
             [api.dt-util-test :refer [generate-random-datetime, generate-random-hour, generate-random-minute, get-later-datetime,
-                                      generate-random-monday-datetime]])
+                                      generate-random-monday-datetime, generate-two-random-sorted-datetimes]])
   (:import org.bson.types.ObjectId))
 
 (def generate-random-specific-day-of-week-frequency
@@ -117,3 +117,12 @@
                           vector)
                      (range (inc days-to-add)))
                 (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))))
+
+(defspec create-habit-goal-fragment-test
+         20
+         (prop/for-all [[start-date end-date :as datetimes] generate-two-random-sorted-datetimes
+                        single-date generate-random-datetime]
+           (and (= {:start-date start-date, :end-date end-date, :total-done 0, :successful false}
+                   (create-habit-goal-fragment datetimes))
+                (= {:start-date single-date, :end-date single-date, :total-done 0, :successful false}
+                   (create-habit-goal-fragment [single-date])))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -128,17 +128,14 @@
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
          number-of-test-check-iterations
-         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
-                        total-week-frequency generate-random-total-week-frequency,
-                        every-x-days-frequency generate-random-every-x-days-frequency,
+         (prop/for-all [freq (gen/one-of [generate-random-specific-day-of-week-frequency,
+                                          generate-random-total-week-frequency,
+                                          generate-random-every-x-days-frequency])
                         {:keys [from-date until-date days-apart]} dt-util-test/generate-two-random-datetimes-with-days-apart]
-           (let [total-span (inc days-apart)]
-             (and (= total-span
-                     (count (freq-stats-util/partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
-                  (== (Math/ceil (/ total-span 7))
-                      (count (freq-stats-util/partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))
-                  (== (Math/ceil (/ total-span (:days every-x-days-frequency)))
-                      (count (freq-stats-util/partition-datetimes-based-on-habit-goal every-x-days-frequency from-date until-date)))))))
+           (let [total-span (inc days-apart),
+                 fragment-length (freq-stats-util/get-habit-goal-fragment-length freq)]
+             (== (Math/ceil (/ total-span fragment-length))
+                 (count (freq-stats-util/partition-datetimes-based-on-habit-goal freq from-date until-date))))))
 
 (defspec partition-datetimes-based-on-habit-goal-specific-day-of-week-frequency-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -191,3 +191,12 @@
                              outside-range-record-b]]
              (= [within-range-record-a, within-range-record-b]
                 (freq-stats-util/get-habit-data-during-fragment habit-data habit-goal-fragment)))))
+
+(defspec evaluate-habit-goal-fragment-total-done-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {}),
+                        amounts (gen/vector gen/nat)]
+           (let [habit-data-during-fragment (map #(random-habit-day-record {:gen-amount (gen/return %)})
+                                                 amounts)]
+             (= (update habit-goal-fragment :total-done + (apply + amounts))
+                (freq-stats-util/evaluate-habit-goal-fragment-total-done habit-goal-fragment habit-data-during-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -8,7 +8,7 @@
                                          get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
                                          span-of-habit-goal-fragment, during-habit-goal-fragment?, get-habit-data-during-fragment]]
             [api.dt-util-test :refer [generate-random-datetime, generate-random-monday-datetime, generate-two-random-sorted-datetimes,
-                                      generate-two-random-datetimes-with-days-apart, generate-random-datetime-d-days-later]])
+                                      generate-two-random-datetimes-with-days-apart, generate-random-datetime-on-given-date]])
   (:import org.bson.types.ObjectId))
 
 (def generate-random-specific-day-of-week-frequency
@@ -139,7 +139,8 @@
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
                         days-to-add gen/int]
            (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date),
-                 datetime (gen/generate (generate-random-datetime-d-days-later from-date days-to-add))]
+                 datetime (t/plus (gen/generate (generate-random-datetime-on-given-date from-date))
+                                  (t/days days-to-add))]
              (= (<= 0 days-to-add days-apart)
                 (during-habit-goal-fragment? datetime habit-goal-fragment)))))
 

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -118,13 +118,11 @@
 
 (defspec get-habit-start-date-other-frequencies-test
          number-of-test-check-iterations
-         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
-                        every-x-days-frequency generate-random-every-x-days-frequency]
+         (prop/for-all [freq (gen/one-of [generate-random-specific-day-of-week-frequency, generate-random-every-x-days-frequency])]
            (let [sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector dt-util-test/generate-random-datetime))))
                  sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) sorted-datetimes)]
              (= (first sorted-datetimes)
-                (freq-stats-util/get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
-                (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency)))))
+                (freq-stats-util/get-habit-start-date sorted-habit-data freq)))))
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -200,3 +200,11 @@
                                                  amounts)]
              (= (update habit-goal-fragment :total-done + (apply + amounts))
                 (freq-stats-util/evaluate-habit-goal-fragment-total-done habit-goal-fragment habit-data-during-fragment)))))
+
+(defspec evaluate-habit-goal-fragment-successful-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-goal-fragment (generate-random-habit-goal-fragment {}),
+                        total-week-frequency generate-random-total-week-frequency]
+           (let [habit-type "bad_habit"]
+             (= (assoc habit-goal-fragment :successful (<= (:total-done habit-goal-fragment) (:week total-week-frequency)))
+                (freq-stats-util/evaluate-habit-goal-fragment-successful habit-goal-fragment habit-type total-week-frequency)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -135,41 +135,21 @@
              (== (Math/ceil (/ total-span fragment-length))
                  (count (freq-stats-util/partition-datetimes-based-on-habit-goal freq from-date until-date))))))
 
-(defspec partition-datetimes-based-on-habit-goal-specific-day-of-week-frequency-test
+(defspec partition-datetimes-based-on-habit-goal-two-fragments-test
          number-of-test-check-iterations
-         (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
-                        {:keys [from-date until-date days-apart]} dt-util-test/generate-two-random-datetimes-with-days-apart]
-           (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date)]
-             (= (map #(-> from-date-at-start-of-day
-                          (t/plus (t/days %))
-                          vector)
-                     (range (inc days-apart)))
-                (freq-stats-util/partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))))
-
-(defspec partition-datetimes-based-on-habit-goal-total-week-frequency-test
-         number-of-test-check-iterations
-         (prop/for-all [total-week-frequency generate-random-total-week-frequency,
+         (prop/for-all [freq (gen/one-of [generate-random-specific-day-of-week-frequency,
+                                          generate-random-total-week-frequency,
+                                          generate-random-every-x-days-frequency])
                         from-date dt-util-test/generate-random-datetime]
-           (let [until-date (dt-util-test/random-datetime-on-given-date (t/plus from-date (t/days 8))),
+           (let [fragment-length (freq-stats-util/get-habit-goal-fragment-length freq),
+                 days-in-remaining-fragment (gen/generate (gen/choose 1 fragment-length)),
+                 days-to-add (dec (+ fragment-length days-in-remaining-fragment)),
+                 until-date (dt-util-test/random-datetime-on-given-date (t/plus from-date (t/days days-to-add))),
                  from-date-at-start-of-day (t/with-time-at-start-of-day from-date),
-                 first-week-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 7)),
-                 remaining-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 7 9))]
-             (= [first-week-datetimes, remaining-datetimes]
-                (freq-stats-util/partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))))
-
-(defspec partition-datetimes-based-on-habit-goal-every-x-days-frequency-test
-         number-of-test-check-iterations
-         (prop/for-all [times gen/nat,
-                        from-date dt-util-test/generate-random-datetime]
-           (let [every-x-days-frequency {:type_name "every_x_days_frequency",
-                                         :times times,
-                                         :days 12}
-                 until-date (dt-util-test/random-datetime-on-given-date (t/plus from-date (t/days 18))),
-                 from-date-at-start-of-day (t/with-time-at-start-of-day from-date),
-                 first-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 12)),
-                 remaining-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 12 19))]
-             (= [first-datetimes, remaining-datetimes]
-                (freq-stats-util/partition-datetimes-based-on-habit-goal every-x-days-frequency from-date until-date)))))
+                 first-fragment (map #(t/plus from-date-at-start-of-day (t/days %)) (range fragment-length)),
+                 remaining-fragment (map #(t/plus from-date-at-start-of-day (t/days %)) (range fragment-length (inc days-to-add)))]
+             (= [first-fragment, remaining-fragment]
+                (freq-stats-util/partition-datetimes-based-on-habit-goal freq from-date until-date)))))
 
 (defspec create-habit-goal-fragment-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -146,6 +146,17 @@
                      (range (inc days-apart)))
                 (freq-stats-util/partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))))
 
+(defspec partition-datetimes-based-on-habit-goal-total-week-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [total-week-frequency generate-random-total-week-frequency,
+                        from-date dt-util-test/generate-random-datetime]
+           (let [until-date (dt-util-test/random-datetime-on-given-date (t/plus from-date (t/days 8))),
+                 from-date-at-start-of-day (t/with-time-at-start-of-day from-date),
+                 first-week-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 7)),
+                 remaining-datetimes (map #(t/plus from-date-at-start-of-day (t/days %)) (range 7 9))]
+             (= [first-week-datetimes, remaining-datetimes]
+                (freq-stats-util/partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))))
+
 (defspec create-habit-goal-fragment-test
          number-of-test-check-iterations
          (prop/for-all [[start-date end-date :as datetimes] dt-util-test/generate-two-random-sorted-datetimes

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -359,3 +359,30 @@
                                                                          successful-current-fragment
                                                                          total-week-frequency
                                                                          habit-type)))))
+
+(defspec update-freq-stats-with-current-fragment-good-habit-failed-fragment-every-x-days-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-frequency-stats (generate-random-habit-frequency-stats {:gen-best-fragment-streak (gen/return 0)}),
+                        every-x-days-frequency generate-random-every-x-days-frequency,
+                        current-fragment-start-date dt-util-test/generate-random-datetime,
+                        num-days-later (gen/choose 0 6)]
+           (let [current-fragment-end-date (t/plus current-fragment-start-date (t/days num-days-later)),
+                 failed-current-fragment (random-habit-goal-fragment {:gen-start-date (gen/return current-fragment-start-date),
+                                                                      :gen-end-date (gen/return current-fragment-end-date),
+                                                                      :gen-successful (gen/return true)}),
+                 habit-type "good_habit",
+                 total-done (:total-done failed-current-fragment),
+                 new-current-fragment-streak (inc (:current_fragment_streak habit-frequency-stats))]
+             (= (-> habit-frequency-stats
+                    (update :total_fragments inc)
+                    (update :successful_fragments inc)
+                    (update :total_done + total-done)
+                    (assoc :current_fragment_streak new-current-fragment-streak)
+                    (assoc :best_fragment_streak new-current-fragment-streak)
+                    (assoc :current_fragment_total total-done)
+                    (assoc :current_fragment_goal (:times every-x-days-frequency))
+                    (assoc :current_fragment_days_left (- (:days every-x-days-frequency) (inc num-days-later))))
+                (freq-stats-util/update-freq-stats-with-current-fragment habit-frequency-stats
+                                                                         failed-current-fragment
+                                                                         every-x-days-frequency
+                                                                         habit-type)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -5,7 +5,8 @@
             [clj-time.core :as t]
             [api.dt-util :refer [days-spanned-between-datetimes]]
             [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
-                                         get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment]]
+                                         get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
+                                         span-of-habit-goal-fragment]]
             [api.dt-util-test :refer [generate-random-datetime, generate-random-hour, generate-random-minute, get-later-datetime,
                                       generate-random-monday-datetime, generate-two-random-sorted-datetimes]])
   (:import org.bson.types.ObjectId))
@@ -126,3 +127,16 @@
                    (create-habit-goal-fragment datetimes))
                 (= {:start-date single-date, :end-date single-date, :total-done 0, :successful false}
                    (create-habit-goal-fragment [single-date])))))
+
+(defspec span-of-habit-goal-fragment-test
+         20
+         (prop/for-all [start-date generate-random-datetime,
+                        days-to-add gen/nat,
+                        end-date-hour generate-random-hour,
+                        end-date-minute generate-random-minute,
+                        total-done gen/nat,
+                        successful gen/boolean]
+           (let [end-date (get-later-datetime start-date days-to-add end-date-hour end-date-minute),
+                 habit-goal-fragment {:start-date start-date, :end-date end-date, :total-done total-done, :successful successful}]
+             (= (inc days-to-add)
+                (span-of-habit-goal-fragment habit-goal-fragment)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -435,3 +435,25 @@
                                                                          failed-current-fragment
                                                                          specific-day-of-week-frequency
                                                                          habit-type)))))
+
+(defspec update-freq-stats-with-current-fragment-bad-habit-successful-fragment-total-week-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-frequency-stats (generate-random-habit-frequency-stats {}),
+                        total-week-frequency generate-random-total-week-frequency,
+                        current-fragment-start-date dt-util-test/generate-random-datetime,
+                        num-days-later (gen/choose 0 6)]
+           (let [current-fragment-end-date (t/plus current-fragment-start-date (t/days num-days-later)),
+                 successful-current-fragment (random-habit-goal-fragment {:gen-start-date (gen/return current-fragment-start-date),
+                                                                          :gen-end-date (gen/return current-fragment-end-date),
+                                                                          :gen-successful (gen/return true),})
+                 habit-type "bad_habit",
+                 total-done (:total-done successful-current-fragment)]
+             (= (-> habit-frequency-stats
+                    (update :total_done + total-done)
+                    (assoc :current_fragment_total total-done)
+                    (assoc :current_fragment_goal (:week total-week-frequency))
+                    (assoc :current_fragment_days_left (- 7 (inc num-days-later))))
+                (freq-stats-util/update-freq-stats-with-current-fragment habit-frequency-stats
+                                                                         successful-current-fragment
+                                                                         total-week-frequency
+                                                                         habit-type)))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -7,8 +7,7 @@
             [api.freq-stats-util :refer [get-habit-goal-fragment-length, get-habit-goal-amount-for-datetime,
                                          get-habit-start-date, partition-datetimes-based-on-habit-goal, create-habit-goal-fragment,
                                          span-of-habit-goal-fragment]]
-            [api.dt-util-test :refer [generate-random-datetime, generate-random-hour, generate-random-minute, get-later-datetime,
-                                      generate-random-monday-datetime, generate-two-random-sorted-datetimes,
+            [api.dt-util-test :refer [generate-random-datetime, generate-random-monday-datetime, generate-two-random-sorted-datetimes,
                                       generate-two-random-datetimes-with-days-apart]])
   (:import org.bson.types.ObjectId))
 

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -110,9 +110,9 @@
                         days-to-add gen/nat,
                         until-date-hour generate-random-hour,
                         until-date-minute generate-random-minute]
-           (let [until-date (get-later-datetime from-date days-to-add until-date-hour until-date-minute)]
-             (= (map #(-> from-date
-                          t/with-time-at-start-of-day
+           (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date),
+                 until-date (get-later-datetime from-date days-to-add until-date-hour until-date-minute)]
+             (= (map #(-> from-date-at-start-of-day
                           (t/plus (t/days %))
                           vector)
                      (range (inc days-to-add)))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -28,10 +28,12 @@
 (def generate-random-ID
   (gen/fmap (fn [_] (ObjectId.)) gen/int))
 
-(def generate-random-habit-day-record
+(defn generate-random-habit-day-record-with-given-date
+  "Returns a generator for a random `habit_day_record` with specified `date` field, and random other fields."
+  [date]
   (gen/hash-map :_id generate-random-ID,
                 :habit_id generate-random-ID,
-                :date generate-random-datetime,
+                :date (gen/return date),
                 :amount gen/nat))
 
 (defn random-habit-goal-fragment-with-given-dates
@@ -84,11 +86,10 @@
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
-                        habit-day-record generate-random-habit-day-record,
                         monday-dt generate-random-monday-datetime,
                         days-to-add (gen/choose 0 6)]
            (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
-                 sorted-habit-data [(assoc habit-day-record :date later-in-week-dt)]]
+                 sorted-habit-data [(gen/generate (generate-random-habit-day-record-with-given-date later-in-week-dt))]]
              (and (= monday-dt (get-habit-start-date sorted-habit-data total-week-frequency))
                   (= later-in-week-dt (get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
                         (get-habit-start-date sorted-habit-data every-x-days-frequency))))))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -11,6 +11,8 @@
                                       generate-two-random-datetimes-with-days-apart, generate-random-datetime-on-given-date]])
   (:import org.bson.types.ObjectId))
 
+(def number-of-test-check-iterations 30)
+
 (def generate-random-specific-day-of-week-frequency
   (gen/hash-map :type_name (gen/return "specific_day_of_week_frequency"),
                 :monday gen/nat, :tuesday gen/nat, :wednesday gen/nat, :thursday gen/nat,
@@ -46,22 +48,22 @@
                   {:start-date start-date, :end-date end-date, :total-done total-done, :successful successful})))
 
 (defspec get-habit-goal-fragment-length-specific-day-of-week-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-specific-day-of-week-frequency]
            (= 1 (get-habit-goal-fragment-length freq))))
 
 (defspec get-habit-goal-fragment-length-total-week-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-total-week-frequency]
            (= 7 (get-habit-goal-fragment-length freq))))
 
 (defspec get-habit-goal-fragment-length-every-x-days-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-every-x-days-frequency]
            (= (:days freq) (get-habit-goal-fragment-length freq))))
 
 (defspec get-habit-goal-amount-for-datetime-specific-day-of-week-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-specific-day-of-week-frequency,
                         dt generate-random-monday-datetime]
            (and (= (:monday freq) (get-habit-goal-amount-for-datetime dt freq))
@@ -73,19 +75,19 @@
                 (= (:sunday freq) (get-habit-goal-amount-for-datetime (t/plus dt (t/days 6)) freq)))))
 
 (defspec get-habit-goal-amount-for-datetime-total-week-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-total-week-frequency,
                         dt generate-random-datetime]
            (= (:week freq) (get-habit-goal-amount-for-datetime dt freq))))
 
 (defspec get-habit-goal-amount-for-datetime-every-x-days-frequency-test
-         10
+         number-of-test-check-iterations
          (prop/for-all [freq generate-random-every-x-days-frequency,
                         dt generate-random-datetime]
            (= (:times freq) (get-habit-goal-amount-for-datetime dt freq))))
 
 (defspec get-habit-start-date-test
-         50
+         number-of-test-check-iterations
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
@@ -98,7 +100,7 @@
                         (get-habit-start-date sorted-habit-data every-x-days-frequency))))))
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
@@ -111,7 +113,7 @@
                       (count (partition-datetimes-based-on-habit-goal every-x-days-frequency from-date until-date)))))))
 
 (defspec partition-datetimes-based-on-habit-goal-specific-day-of-week-frequency-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         {:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
            (let [from-date-at-start-of-day (t/with-time-at-start-of-day from-date)]
@@ -122,7 +124,7 @@
                 (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))))
 
 (defspec create-habit-goal-fragment-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [[start-date end-date :as datetimes] generate-two-random-sorted-datetimes
                         single-date generate-random-datetime]
            (and (= {:start-date start-date, :end-date end-date, :total-done 0, :successful false}
@@ -131,14 +133,14 @@
                    (create-habit-goal-fragment [single-date])))))
 
 (defspec span-of-habit-goal-fragment-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart]
            (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date)]
              (= (inc days-apart)
                 (span-of-habit-goal-fragment habit-goal-fragment)))))
 
 (defspec during-habit-goal-fragment?-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [{:keys [from-date until-date days-apart]} generate-two-random-datetimes-with-days-apart,
                         days-to-add gen/int]
            (let [habit-goal-fragment (random-habit-goal-fragment-with-given-dates from-date until-date),
@@ -148,7 +150,7 @@
                 (during-habit-goal-fragment? datetime habit-goal-fragment)))))
 
 (defspec get-habit-data-during-fragment-test
-         20
+         number-of-test-check-iterations
          (prop/for-all [[from-date until-date] generate-two-random-sorted-datetimes
                         days-to-subtract gen/s-pos-int
                         days-to-add gen/s-pos-int]

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -106,18 +106,27 @@
                         dt dt-util-test/generate-random-datetime]
            (= (:times freq) (freq-stats-util/get-habit-goal-amount-for-datetime dt freq))))
 
-(defspec get-habit-start-date-test
+(defspec get-habit-start-date-total-week-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [total-week-frequency generate-random-total-week-frequency,
+                        monday-dt dt-util-test/generate-random-monday-datetime]
+           (let [same-week-sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector (gen/fmap #(t/plus monday-dt (t/days %))
+                                                                                                     (gen/choose 0 6))))))
+                 same-week-sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) same-week-sorted-datetimes)]
+             (= monday-dt
+                (freq-stats-util/get-habit-start-date same-week-sorted-habit-data total-week-frequency)))))
+
+(defspec get-habit-start-date-other-frequencies-test
          number-of-test-check-iterations
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
-                        total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
-                        monday-dt dt-util-test/generate-random-monday-datetime,
-                        days-to-add (gen/choose 0 6)]
-           (let [later-in-week-dt (t/plus monday-dt (t/days days-to-add)),
-                 sorted-habit-data [(random-habit-day-record {:gen-date (gen/return later-in-week-dt)})]]
-             (and (= monday-dt (freq-stats-util/get-habit-start-date sorted-habit-data total-week-frequency))
-                  (= later-in-week-dt (freq-stats-util/get-habit-start-date sorted-habit-data specific-day-of-week-frequency)
-                                      (freq-stats-util/get-habit-start-date sorted-habit-data every-x-days-frequency))))))
+                        monday-dt dt-util-test/generate-random-monday-datetime]
+           (let [same-week-sorted-datetimes (sort (gen/generate (gen/not-empty (gen/vector (gen/fmap #(t/plus monday-dt (t/days %))
+                                                                                                     (gen/choose 0 6))))))
+                 same-week-sorted-habit-data (map #(random-habit-day-record {:gen-date (gen/return %)}) same-week-sorted-datetimes)]
+             (= (first same-week-sorted-datetimes)
+                (freq-stats-util/get-habit-start-date same-week-sorted-habit-data specific-day-of-week-frequency)
+                (freq-stats-util/get-habit-start-date same-week-sorted-habit-data every-x-days-frequency)))))
 
 (defspec partition-datetimes-based-on-habit-goal-count-test
          number-of-test-check-iterations

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -93,12 +93,8 @@
          (prop/for-all [specific-day-of-week-frequency generate-random-specific-day-of-week-frequency,
                         total-week-frequency generate-random-total-week-frequency,
                         every-x-days-frequency generate-random-every-x-days-frequency,
-                        from-date generate-random-datetime,
-                        days-to-add gen/nat,
-                        until-date-hour generate-random-hour,
-                        until-date-minute generate-random-minute]
-           (let [until-date (get-later-datetime from-date days-to-add until-date-hour until-date-minute)
-                 total-span (days-spanned-between-datetimes from-date until-date)]
+                        [from-date until-date] generate-two-random-sorted-datetimes]
+           (let [total-span (days-spanned-between-datetimes from-date until-date)]
              (and (= total-span (count (partition-datetimes-based-on-habit-goal specific-day-of-week-frequency from-date until-date)))
                   (== (Math/ceil (/ total-span 7))
                       (count (partition-datetimes-based-on-habit-goal total-week-frequency from-date until-date)))

--- a/api/test/api/freq_stats_util_test.clj
+++ b/api/test/api/freq_stats_util_test.clj
@@ -332,3 +332,30 @@
                     (assoc :current_fragment_streak new-current-fragment-streak)
                     (assoc :best_fragment_streak new-current-fragment-streak))
                 (freq-stats-util/update-freq-stats-with-past-fragment habit-frequency-stats successful-habit-goal-fragment)))))
+
+(defspec update-freq-stats-with-current-fragment-good-habit-successful-fragment-total-week-frequency-test
+         number-of-test-check-iterations
+         (prop/for-all [habit-frequency-stats (generate-random-habit-frequency-stats {:gen-best-fragment-streak (gen/return 0)}),
+                        total-week-frequency generate-random-total-week-frequency,
+                        current-fragment-start-date dt-util-test/generate-random-datetime,
+                        num-days-later (gen/choose 0 6)]
+           (let [current-fragment-end-date (t/plus current-fragment-start-date (t/days num-days-later)),
+                 successful-current-fragment (random-habit-goal-fragment {:gen-start-date (gen/return current-fragment-start-date),
+                                                                          :gen-end-date (gen/return current-fragment-end-date),
+                                                                          :gen-successful (gen/return true)}),
+                 habit-type "good_habit",
+                 total-done (:total-done successful-current-fragment),
+                 new-current-fragment-streak (inc (:current_fragment_streak habit-frequency-stats))]
+             (= (-> habit-frequency-stats
+                    (update :total_fragments inc)
+                    (update :successful_fragments inc)
+                    (update :total_done + total-done)
+                    (assoc :current_fragment_streak new-current-fragment-streak)
+                    (assoc :best_fragment_streak new-current-fragment-streak)
+                    (assoc :current_fragment_total total-done)
+                    (assoc :current_fragment_goal (:week total-week-frequency))
+                    (assoc :current_fragment_days_left (- 7 (inc num-days-later))))
+                (freq-stats-util/update-freq-stats-with-current-fragment habit-frequency-stats
+                                                                         successful-current-fragment
+                                                                         total-week-frequency
+                                                                         habit-type)))))

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -1,0 +1,10077 @@
+{
+  "name": "Habby-Web-Client",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "dev": true
+    },
+    "acorn-dynamic-import": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "dev": true
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000842",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.7",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
+          "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000842",
+            "electron-to-chromium": "1.3.47"
+          }
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.6",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.6",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        }
+      }
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "dev": true
+        }
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.1",
+        "evp_bytestokey": "1.0.3"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "requires": {
+        "pako": "1.0.6"
+      }
+    },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "1.0.30000842",
+        "electron-to-chromium": "1.3.47"
+      }
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.11",
+        "isarray": "1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "cacache": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.3",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.3.0",
+        "unique-filename": "1.1.0",
+        "y18n": "4.0.0"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
+    },
+    "camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000842",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000842",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000842.tgz",
+      "integrity": "sha1-ioLDd7iz1vJZRHjoQx/0/TA+Fgw=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000842",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000842.tgz",
+      "integrity": "sha512-juspQHLwQRgptEM03HN66SpM/ggZUB+m49NAgJIaIS11aXVNeRB57sEY1X6tEzeK2THGvYWKZZu1wIbh+W7YTA==",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+      "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "clone-deep": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
+      "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+      "dev": true,
+      "requires": {
+        "for-own": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "kind-of": "6.0.2",
+        "shallow-clone": "1.0.0"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "requires": {
+        "q": "1.5.1"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.4",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.2",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "2.0.13",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "3.0.0",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "osenv": "0.1.5",
+        "uuid": "2.0.3",
+        "write-file-atomic": "1.3.4",
+        "xdg-basedir": "2.0.0"
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+      "dev": true
+    },
+    "connect-pause": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/connect-pause/-/connect-pause-0.1.0.tgz",
+      "integrity": "sha1-D9d72e+Lpg0KJw7lIxOz2tRsQSo=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-webpack-plugin": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+      "integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
+      "dev": true,
+      "requires": {
+        "cacache": "10.0.4",
+        "find-cache-dir": "1.0.0",
+        "globby": "7.1.1",
+        "is-glob": "4.0.0",
+        "loader-utils": "1.1.0",
+        "minimatch": "3.0.4",
+        "p-limit": "1.2.0",
+        "serialize-javascript": "1.5.0"
+      }
+    },
+    "core-js": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "cosmiconfig": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "require-from-string": "1.2.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
+      "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.3",
+        "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.27.3.tgz",
+      "integrity": "sha1-aatvR7ab+xtazuYbrCqrFDAv8Nw=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "source-list-map": "0.1.8"
+      }
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        }
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "dev": true,
+      "requires": {
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "del": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "dev": true,
+      "requires": {
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
+      }
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
+      }
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "dev": true,
+      "requires": {
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "1.1.1"
+      }
+    },
+    "dom-converter": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+      "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+      "dev": true,
+      "requires": {
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+      "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ=",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "elm": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/elm/-/elm-0.18.0.tgz",
+      "integrity": "sha1-kZuDCc2Tnf4v+dJS2WG2yJUJuXA=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "promise": "7.1.1",
+        "request": "2.74.0",
+        "tar": "2.2.1"
+      }
+    },
+    "elm-webpack-loader": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/elm-webpack-loader/-/elm-webpack-loader-4.5.0.tgz",
+      "integrity": "sha512-bhzj9Aa6GqNRSCUddMwc0CqfCqtSMZFbyUaCt979xl8wPul2zfwYE4w6WRjMXZZx6RFlN9QTDcti9PJQQ0XQNQ==",
+      "dev": true,
+      "requires": {
+        "elm": "0.18.0",
+        "glob": "7.1.2",
+        "loader-utils": "1.1.0",
+        "node-elm-compiler": "4.5.0",
+        "yargs": "6.6.0"
+      }
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
+      "requires": {
+        "prr": "1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "errorhandler": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
+      "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "escape-html": "1.0.3"
+      }
+    },
+    "es-abstract": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "eventsource": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "dev": true,
+      "requires": {
+        "original": "1.0.1"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.4"
+      }
+    },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        }
+      }
+    },
+    "extract-text-webpack-plugin": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
+      "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0",
+        "webpack-sources": "1.1.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
+    },
+    "file-loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
+      "integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.3.0",
+        "pkg-dir": "2.0.0"
+      }
+    },
+    "find-elm-dependencies": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-1.0.2.tgz",
+      "integrity": "sha512-gnvu2zAKFEHd76zV/JkRvof7HNyM2X8yW5vflCfWbXeo9hmXMndz/SrEsTQFSXXgNqf0AdjhQSRPnG8JYR92oQ==",
+      "dev": true,
+      "requires": {
+        "firstline": "1.2.0",
+        "lodash": "4.14.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.14.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz",
+          "integrity": "sha1-u8zOY3OkAPv9CoxnykL20e9BZDI=",
+          "dev": true
+        }
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
+    "firstline": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.0.tgz",
+      "integrity": "sha1-yfSIbn9/vwr8EtcZQdzgaxkq6gU=",
+      "dev": true
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "gaze": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "dev": true,
+      "requires": {
+        "globule": "1.2.0"
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.8",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
+      }
+    },
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4"
+      }
+    },
+    "got": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer2": "0.1.4",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.6",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
+        "url-parse-lax": "1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.15.1",
+        "is-my-json-valid": "2.17.2",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "wbuf": "1.7.3"
+      }
+    },
+    "html-comment-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+      "dev": true
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+      "dev": true
+    },
+    "html-minifier": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
+      "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.15.1",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.3.25"
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
+      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "html-minifier": "3.5.15",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.10",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.7"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+      "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+      "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.4.1",
+        "requires-port": "1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "1.17.0",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.10",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "dev": true
+    },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "internal-ip": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+      "dev": true,
+      "requires": {
+        "meow": "3.7.0"
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jju": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
+      "dev": true
+    },
+    "js-base64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "1.3.0"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-server": {
+      "version": "0.8.23",
+      "resolved": "https://registry.npmjs.org/json-server/-/json-server-0.8.23.tgz",
+      "integrity": "sha1-KOT/1RyNiTKVKA60Bk2XA1lN5aI=",
+      "dev": true,
+      "requires": {
+        "body-parser": "1.18.3",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "compression": "1.7.2",
+        "connect-pause": "0.1.0",
+        "cors": "2.8.4",
+        "errorhandler": "1.5.0",
+        "express": "4.16.3",
+        "lodash": "4.17.10",
+        "lowdb": "0.13.1",
+        "method-override": "2.3.10",
+        "morgan": "1.9.0",
+        "node-uuid": "1.4.8",
+        "object-assign": "4.1.1",
+        "pluralize": "3.1.0",
+        "request": "2.74.0",
+        "server-destroy": "1.0.1",
+        "underscore-db": "0.10.0",
+        "update-notifier": "1.0.3",
+        "yargs": "4.8.1"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "killable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "latest-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "dev": true,
+      "requires": {
+        "package-json": "2.4.0"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+      "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "loader-runner": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "dev": true
+    },
+    "lodash.tail": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+      "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "loglevel": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lowdb": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.13.1.tgz",
+      "integrity": "sha1-67EFcmlyG0DDFs7bGHfmjX8Uygw=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "is-promise": "2.1.0",
+        "json-parse-helpfulerror": "1.0.3",
+        "steno": "0.4.4"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "macaddress": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "method-override": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
+      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "methods": "1.1.2",
+        "parseurl": "1.3.2",
+        "vary": "1.1.2"
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mississippi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+      "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "duplexify": "3.6.0",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.3",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "2.0.1",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "requires": {
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "dev": true,
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "dev": true,
+      "requires": {
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
+      "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
+    },
+    "node-elm-compiler": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-4.5.0.tgz",
+      "integrity": "sha512-XlyiHxqBizqEHaYj4UaO5/qmxeh1Ir/M02RLKsIgHBR7Z8snwoXfdpVntlfF64mcAGkuA1KY0CJsqk0IpAfyLQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.0",
+        "find-elm-dependencies": "1.0.2",
+        "lodash": "4.14.2",
+        "temp": "0.8.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.14.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz",
+          "integrity": "sha1-u8zOY3OkAPv9CoxnykL20e9BZDI=",
+          "dev": true
+        }
+      }
+    },
+    "node-forge": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.5",
+        "request": "2.74.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.2",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      }
+    },
+    "node-sass": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
+      "dev": true,
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.10.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
+        "request": "2.79.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1"
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
+        }
+      }
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "1.1.0"
+      }
+    },
+    "original": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
+      "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
+      "dev": true,
+      "requires": {
+        "url-parse": "1.4.0"
+      }
+    },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "package-json": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "dev": true,
+      "requires": {
+        "got": "5.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
+      }
+    },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+      "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+      "dev": true,
+      "requires": {
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      }
+    },
+    "pluralize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-3.1.0.tgz",
+      "integrity": "sha1-hCE9ChI1YGnaqEBgxVkkJjMWE2g=",
+      "dev": true
+    },
+    "portfinder": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.4.5",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
+      }
+    },
+    "postcss-load-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1",
+        "postcss-load-options": "1.2.0",
+        "postcss-load-plugins": "2.3.0"
+      }
+    },
+    "postcss-load-options": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "postcss-load-plugins": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "postcss-loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
+      "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-load-config": "1.2.0"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.2"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+      "dev": true
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.22"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.22"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+      "dev": true
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.6.0",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+      "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "randombytes": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.5.1",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.7",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.7"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+      "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.7.0",
+        "bl": "1.1.2",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "1.0.1",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.8.2",
+        "qs": "6.2.3",
+        "stringstream": "0.0.6",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.4.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
+      "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
+      "dev": true,
+      "requires": {
+        "clone-deep": "2.0.2",
+        "loader-utils": "1.1.0",
+        "lodash.tail": "4.1.1",
+        "neo-async": "2.5.1",
+        "pify": "3.0.0"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "schema-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2"
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "2.4.5",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+      "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+      "dev": true,
+      "requires": {
+        "node-forge": "0.7.5"
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.5.0"
+      }
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
+    "serialize-javascript": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+      "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+      "dev": true
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "shallow-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
+      "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1",
+        "kind-of": "5.1.0",
+        "mixin-object": "2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "sockjs": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+      "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.10.0",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.0"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-list-map": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.2",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
+      }
+    },
+    "spdy-transport": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "wbuf": "1.7.3"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "ssri": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "steno": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
+      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
+      }
+    },
+    "stream-http": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "style-loader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.16.1.tgz",
+      "integrity": "sha1-UOMlJY1OeEId2WgGNrQehmFZXRA=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "dev": true,
+      "requires": {
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
+      }
+    },
+    "tapable": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
+      }
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
+      }
+    },
+    "thunky": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+      "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
+    "toposort": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "dev": true,
+      "requires": {
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.3.25",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+      "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "underscore-db": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/underscore-db/-/underscore-db-0.10.0.tgz",
+      "integrity": "sha1-pL1/Wpx/Luwx5HhLQCJB3zZnFJk=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqid": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "upath": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "dev": true,
+      "requires": {
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "2.0.0"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-loader": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "mime": "1.3.6"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
+          "dev": true
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "watchpack": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "2.0.3",
+        "graceful-fs": "4.1.11",
+        "neo-async": "2.5.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.1.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        }
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "1.0.1"
+      }
+    },
+    "webpack": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+      "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "async": "2.6.0",
+        "enhanced-resolve": "3.4.1",
+        "interpret": "1.1.0",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.1.0",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3",
+        "tapable": "0.2.8",
+        "uglify-js": "2.8.29",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.1.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "dev": true,
+      "requires": {
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "array-includes": "3.0.3",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.3",
+        "compression": "1.7.2",
+        "connect-history-api-fallback": "1.5.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "import-local": "1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "1.1.5",
+        "killable": "1.0.0",
+        "loglevel": "1.6.1",
+        "opn": "5.3.0",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.3",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.4.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.1.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "webpack-merge": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
+      "integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "webpack-sources": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+      "dev": true,
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.12",
+        "websocket-extensions": "0.1.3"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
+    },
+    "xdg-basedir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      }
+    }
+  }
+}

--- a/web-client/src/Api.elm
+++ b/web-client/src/Api.elm
@@ -7,9 +7,9 @@ import Json.Decode as Decode
 import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.ApiError exposing (ApiError)
+import Models.FrequencyStats as FrequencyStats
 import Models.Habit as Habit
 import Models.HabitData as HabitData
-import Models.FrequencyStats as FrequencyStats
 import Models.YmdDate as YmdDate
 
 
@@ -38,7 +38,7 @@ queryHabitsAndHabitDataAndFrequencyStats :
 queryHabitsAndHabitDataAndFrequencyStats ymd url handleError handleSuccess =
     let
         queryString =
-            ("""{
+            """{
   habits: get_habits {
     __typename
     ... on good_habit {
@@ -108,11 +108,11 @@ queryHabitsAndHabitDataAndFrequencyStats ymd url handleError handleSuccess =
     habit_id
   }
   frequencyStatsList: get_frequency_stats(current_client_date: {year: """
-                ++ (toString ymd.year)
+                ++ toString ymd.year
                 ++ ", month: "
-                ++ (toString ymd.month)
+                ++ toString ymd.month
                 ++ ", day: "
-                ++ (toString ymd.day)
+                ++ toString ymd.day
                 ++ """}) {
     habit_id
     total_fragments
@@ -125,19 +125,18 @@ queryHabitsAndHabitDataAndFrequencyStats ymd url handleError handleSuccess =
     current_fragment_days_left
   }
 }"""
-            )
     in
-        graphQLRequest
-            queryString
-            (decode HabitsAndHabitDataAndFrequencyStats
-                |> required "habits" (Decode.list Habit.decodeHabit)
-                |> required "habitData" (Decode.list HabitData.decodeHabitData)
-                |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
-                |> Decode.at [ "data" ]
-            )
-            url
-            handleError
-            handleSuccess
+    graphQLRequest
+        queryString
+        (decode HabitsAndHabitDataAndFrequencyStats
+            |> required "habits" (Decode.list Habit.decodeHabit)
+            |> required "habitData" (Decode.list HabitData.decodeHabitData)
+            |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
+            |> Decode.at [ "data" ]
+        )
+        url
+        handleError
+        handleSuccess
 
 
 type alias QueriedFrequencyStats =
@@ -155,12 +154,12 @@ queryPastFrequencyStats :
 queryPastFrequencyStats ymd url handleError handleSuccess =
     let
         queryString =
-            ("""{frequencyStatsList: get_frequency_stats(current_client_date: {year: """
-                ++ (toString ymd.year)
+            """{frequencyStatsList: get_frequency_stats(current_client_date: {year: """
+                ++ toString ymd.year
                 ++ ", month: "
-                ++ (toString ymd.month)
+                ++ toString ymd.month
                 ++ ", day: "
-                ++ (toString ymd.day)
+                ++ toString ymd.day
                 ++ """}) {
     habit_id
     total_fragments
@@ -173,17 +172,16 @@ queryPastFrequencyStats ymd url handleError handleSuccess =
     current_fragment_days_left
   }
 }"""
-            )
     in
-        graphQLRequest
-            queryString
-            (decode QueriedFrequencyStats
-                |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
-                |> Decode.at [ "data" ]
-            )
-            url
-            handleError
-            handleSuccess
+    graphQLRequest
+        queryString
+        (decode QueriedFrequencyStats
+            |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
+            |> Decode.at [ "data" ]
+        )
+        url
+        handleError
+        handleSuccess
 
 
 mutationAddHabit : Habit.CreateHabit -> String -> (ApiError -> b) -> (Habit.Habit -> b) -> Cmd b
@@ -349,7 +347,7 @@ mutationAddHabit createHabit =
         }"""
                 |> Util.templater templateDict
     in
-        graphQLRequest queryString <| Decode.at [ "data", "add_habit" ] Habit.decodeHabit
+    graphQLRequest queryString <| Decode.at [ "data", "add_habit" ] Habit.decodeHabit
 
 
 mutationSetHabitData : YmdDate.YmdDate -> String -> Int -> String -> (ApiError -> b) -> (HabitData.HabitData -> b) -> Cmd b
@@ -379,4 +377,4 @@ mutationSetHabitData { day, month, year } habitId amount =
 }"""
                 |> Util.templater templateDict
     in
-        graphQLRequest query (Decode.at [ "data", "set_habit_data" ] HabitData.decodeHabitData)
+    graphQLRequest query (Decode.at [ "data", "set_habit_data" ] HabitData.decodeHabitData)

--- a/web-client/src/Api.elm
+++ b/web-client/src/Api.elm
@@ -123,6 +123,7 @@ queryHabitsAndHabitDataAndFrequencyStats ymd =
     current_fragment_total
     current_fragment_goal
     current_fragment_days_left
+    habit_has_started
   }
 }"""
     in
@@ -167,6 +168,7 @@ queryPastFrequencyStats ymd =
     current_fragment_total
     current_fragment_goal
     current_fragment_days_left
+    habit_has_started
   }
 }"""
     in

--- a/web-client/src/Api.elm
+++ b/web-client/src/Api.elm
@@ -35,7 +35,7 @@ queryHabitsAndHabitDataAndFrequencyStats :
     -> (ApiError -> b)
     -> (HabitsAndHabitDataAndFrequencyStats -> b)
     -> Cmd b
-queryHabitsAndHabitDataAndFrequencyStats ymd url handleError handleSuccess =
+queryHabitsAndHabitDataAndFrequencyStats ymd =
     let
         queryString =
             """{
@@ -134,9 +134,6 @@ queryHabitsAndHabitDataAndFrequencyStats ymd url handleError handleSuccess =
             |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
             |> Decode.at [ "data" ]
         )
-        url
-        handleError
-        handleSuccess
 
 
 type alias QueriedFrequencyStats =
@@ -151,7 +148,7 @@ queryPastFrequencyStats :
     -> (ApiError -> b)
     -> (QueriedFrequencyStats -> b)
     -> Cmd b
-queryPastFrequencyStats ymd url handleError handleSuccess =
+queryPastFrequencyStats ymd =
     let
         queryString =
             """{frequencyStatsList: get_frequency_stats(current_client_date: {year: """
@@ -179,9 +176,6 @@ queryPastFrequencyStats ymd url handleError handleSuccess =
             |> required "frequencyStatsList" (Decode.list FrequencyStats.decodeFrequencyStats)
             |> Decode.at [ "data" ]
         )
-        url
-        handleError
-        handleSuccess
 
 
 mutationAddHabit : Habit.CreateHabit -> String -> (ApiError -> b) -> (Habit.Habit -> b) -> Cmd b

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -72,7 +72,44 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                                 isHabitCurrentFragmentSuccessful habitTwo statsTwo
                         in
                             if isHabitOneAlreadySuccessful == isHabitTwoAlreadySuccessful then
-                                compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+                                let
+                                    daysLeftComparison =
+                                        compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+                                in
+                                    case daysLeftComparison of
+                                        EQ ->
+                                            -- further sort by current fragment progress
+                                            let
+                                                getCurrentProgress : FrequencyStats.FrequencyStats -> Float
+                                                getCurrentProgress stats =
+                                                    ((toFloat stats.currentFragmentTotal)
+                                                        / (toFloat stats.currentFragmentGoal)
+                                                    )
+
+                                                ( habitOneProgress, habitTwoProgress ) =
+                                                    ( getCurrentProgress statsOne, getCurrentProgress statsTwo )
+                                            in
+                                                case ( habitOne, habitTwo ) of
+                                                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+                                                        -- The more progress the user has made, the less behind they are on
+                                                        -- the habit, so display it further down
+                                                        compare habitOneProgress habitTwoProgress
+
+                                                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+                                                        -- The more poorly the user has done, the more they should see it prominently
+                                                        -- displayed so they can be aware and work on it
+                                                        compare habitTwoProgress habitOneProgress
+
+                                                    ( Habit.GoodHabit _, Habit.BadHabit _ ) ->
+                                                        -- We probably shouldn't be sorting good habits and bad habits together,
+                                                        -- but if we are, we should display good habits first.
+                                                        LT
+
+                                                    _ ->
+                                                        GT
+
+                                        _ ->
+                                            daysLeftComparison
                             else if isHabitOneAlreadySuccessful then
                                 -- We know they are different so if `isHabitOneAlreadySuccessful` is true
                                 -- then `isHabitTwoAlreadySuccessful` must be false

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -23,112 +23,136 @@ findFrequencyStatsForHabit habit frequencyStats =
         |> List.head
 
 
-{-| Returns the habits sorted by completion, urgency, and current goal progress.
+type alias HabitStatsPair =
+    ( Habit.Habit, FrequencyStats.FrequencyStats )
+
+
+{-| For comparing 2 instances of `t`.
+-}
+type alias Comparator t =
+    t -> t -> Order
+
+
+{-| To be able to sort by multiple comparators (for breaking ties).
+Inspired by <https://github.com/amilner42/code-tidbit/blob/a8a8b3b169eb7a4c929788095ae43353d6559752/frontend/src/DefaultServices/Sort.elm#L24>
+-}
+compareByAll : List (Comparator t) -> Comparator t
+compareByAll comparators tOne tTwo =
+    case comparators of
+        [] ->
+            EQ
+
+        comparator :: restOfComparators ->
+            case comparator tOne tTwo of
+                LT ->
+                    LT
+
+                GT ->
+                    GT
+
+                EQ ->
+                    compareByAll restOfComparators tOne tTwo
+
+
+{-| Compares two habits by whether or not their current fragment goals have already been achieved. Prioritizes incomplete habits.
+-}
+compareHabitsByCompletion : Comparator HabitStatsPair
+compareHabitsByCompletion ( habitOne, statsOne ) ( habitTwo, statsTwo ) =
+    let
+        isHabitOneGoalCompleted =
+            isHabitCurrentFragmentSuccessful habitOne statsOne
+
+        isHabitTwoGoalCompleted =
+            isHabitCurrentFragmentSuccessful habitTwo statsTwo
+    in
+    if isHabitOneGoalCompleted == isHabitTwoGoalCompleted then
+        EQ
+    else if isHabitOneGoalCompleted then
+        -- habit one is already complete, habit two is not
+        GT
+    else
+        -- habit two is already complete, habit one is not
+        LT
+
+
+{-| Compares habits by urgency (days left in the current fragment). Prioritizes urgent habits.
+-}
+compareHabitsByDaysLeft : Comparator HabitStatsPair
+compareHabitsByDaysLeft ( habitOne, statsOne ) ( habitTwo, statsTwo ) =
+    compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+
+
+{-| Compares habits by progress proportional to the current fragment goal. Prioritizes further-behind habits.
+-}
+compareHabitsByCurrentGoalProgress : Comparator HabitStatsPair
+compareHabitsByCurrentGoalProgress ( habitOne, statsOne ) ( habitTwo, statsTwo ) =
+    let
+        -- Progress proportional to goal, e.g. 0.3 if the user has done 30% of the goal
+        getCurrentGoalProgressFraction : FrequencyStats.FrequencyStats -> Float
+        getCurrentGoalProgressFraction stats =
+            toFloat stats.currentFragmentTotal
+                / toFloat stats.currentFragmentGoal
+
+        ( habitOneGoalProgressFraction, habitTwoGoalProgressFraction ) =
+            ( getCurrentGoalProgressFraction statsOne, getCurrentGoalProgressFraction statsTwo )
+    in
+    case ( habitOne, habitTwo ) of
+        ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+            -- The higher the fraction, the better the user is doing
+            compare habitOneGoalProgressFraction habitTwoGoalProgressFraction
+
+        ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+            -- The higher the fraction, the worse the user is doing
+            compare habitTwoGoalProgressFraction habitOneGoalProgressFraction
+
+        ( Habit.GoodHabit _, _ ) ->
+            -- We probably shouldn't be sorting good habits and bad habits together,
+            -- but if we are, we should display good habits first.
+            LT
+
+        _ ->
+            GT
+
+
+{-| Compares habits by how much of the current goal remains to be done. Prioritizes further-behind habits.
+-}
+compareHabitsByCurrentGoalRemaining : Comparator HabitStatsPair
+compareHabitsByCurrentGoalRemaining ( habitOne, statsOne ) ( habitTwo, statsTwo ) =
+    let
+        getCurrentGoalRemaining stats =
+            stats.currentFragmentGoal - stats.currentFragmentTotal
+
+        ( habitOneGoalRemaining, habitTwoGoalRemaining ) =
+            ( getCurrentGoalRemaining statsOne, getCurrentGoalRemaining statsTwo )
+    in
+    case ( habitOne, habitTwo ) of
+        ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+            -- The more there is left to do for habit one, the worse it is doing
+            compare habitTwoGoalRemaining habitOneGoalRemaining
+
+        ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+            -- The bigger the difference between the goal and the total, the better
+            -- the user is doing, the further down the list we should display the habit
+            compare habitOneGoalRemaining habitTwoGoalRemaining
+
+        ( Habit.GoodHabit _, _ ) ->
+            -- We probably shouldn't be sorting good habits and bad habits together,
+            -- but if we are, we should display good habits first.
+            LT
+
+        _ ->
+            GT
+
+
+{-| Returns the habits sorted by their progress in the current fragment.
+Sorts first by completion, then by urgency, then by progress proportional to the current goal,
+and then by how much (absolute, not proportional) of the current goal remains to be done.
 -}
 sortHabitsByCurrentFragment : List FrequencyStats.FrequencyStats -> List Habit.Habit -> List Habit.Habit
 sortHabitsByCurrentFragment frequencyStatsList habits =
     let
-        -- Compare habits by completion: show incomplete habits first
-        compareHabitsByCompletion :
-            Habit.Habit
-            -> Habit.Habit
-            -> FrequencyStats.FrequencyStats
-            -> FrequencyStats.FrequencyStats
-            -> Order
-        compareHabitsByCompletion habitOne habitTwo statsOne statsTwo =
-            let
-                isHabitOneGoalCompleted =
-                    isHabitCurrentFragmentSuccessful habitOne statsOne
-
-                isHabitTwoGoalCompleted =
-                    isHabitCurrentFragmentSuccessful habitTwo statsTwo
-            in
-            if isHabitOneGoalCompleted == isHabitTwoGoalCompleted then
-                EQ
-            else if isHabitOneGoalCompleted then
-                -- habit one is already complete, habit two is not
-                GT
-            else
-                -- habit two is already complete, habit one is not
-                LT
-
-        --Compare habits by urgency: show urgent habits first
-        compareHabitsByDaysLeft : FrequencyStats.FrequencyStats -> FrequencyStats.FrequencyStats -> Order
-        compareHabitsByDaysLeft statsOne statsTwo =
-            compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
-
-        --Compare habits by current goal progress: Show habits that the user is further behind on first
-        compareHabitsByCurrentGoalProgress :
-            Habit.Habit
-            -> Habit.Habit
-            -> FrequencyStats.FrequencyStats
-            -> FrequencyStats.FrequencyStats
-            -> Order
-        compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo =
-            let
-                -- Progress relative to goal, e.g. 0.3 if the user has done 30% of the goal
-                getCurrentGoalProgressFraction : FrequencyStats.FrequencyStats -> Float
-                getCurrentGoalProgressFraction stats =
-                    toFloat stats.currentFragmentTotal
-                        / toFloat stats.currentFragmentGoal
-
-                ( habitOneGoalProgressFraction, habitTwoGoalProgressFraction ) =
-                    ( getCurrentGoalProgressFraction statsOne, getCurrentGoalProgressFraction statsTwo )
-            in
-            case ( habitOne, habitTwo ) of
-                ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
-                    -- The more progress the user has made, the less behind they are on
-                    -- the habit, so display it further down
-                    compare habitOneGoalProgressFraction habitTwoGoalProgressFraction
-
-                ( Habit.BadHabit _, Habit.BadHabit _ ) ->
-                    -- The more poorly the user has done, the more they should see it prominently
-                    -- displayed so they can be aware and work on it
-                    compare habitTwoGoalProgressFraction habitOneGoalProgressFraction
-
-                ( Habit.GoodHabit _, _ ) ->
-                    -- We probably shouldn't be sorting good habits and bad habits together,
-                    -- but if we are, we should display good habits first.
-                    LT
-
-                _ ->
-                    GT
-
-        -- Compare habits by current goal remaining: Show habits that the user has more to do of first
-        compareHabitsByCurrentGoalRemaining :
-            Habit.Habit
-            -> Habit.Habit
-            -> FrequencyStats.FrequencyStats
-            -> FrequencyStats.FrequencyStats
-            -> Order
-        compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo =
-            let
-                getCurrentGoalRemaining stats =
-                    stats.currentFragmentGoal - stats.currentFragmentTotal
-
-                ( habitOneGoalRemaining, habitTwoGoalRemaining ) =
-                    ( getCurrentGoalRemaining statsOne, getCurrentGoalRemaining statsTwo )
-            in
-            case ( habitOne, habitTwo ) of
-                ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
-                    -- The more there is left to do for habit one, the worse it is doing
-                    compare habitTwoGoalRemaining habitOneGoalRemaining
-
-                ( Habit.BadHabit _, Habit.BadHabit _ ) ->
-                    -- The bigger the difference between the goal and the total, the better
-                    -- the user is doing, the further down the list we should display the habit
-                    compare habitOneGoalRemaining habitTwoGoalRemaining
-
-                ( Habit.GoodHabit _, _ ) ->
-                    -- We probably shouldn't be sorting good habits and bad habits together,
-                    -- but if we are, we should display good habits first.
-                    LT
-
-                _ ->
-                    GT
-
-        compareHabits : Habit.Habit -> Habit.Habit -> Order
-        compareHabits habitOne habitTwo =
+        compareHabitsByCurrentFragment : Comparator Habit.Habit
+        compareHabitsByCurrentFragment habitOne habitTwo =
             let
                 habitOneFrequencyStats =
                     findFrequencyStatsForHabit habitOne frequencyStatsList
@@ -147,27 +171,13 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                     LT
 
                 ( Just statsOne, Just statsTwo ) ->
-                    let
-                        completionComparison =
-                            compareHabitsByCompletion habitOne habitTwo statsOne statsTwo
-                    in
-                    if completionComparison == EQ then
-                        let
-                            daysLeftComparison =
-                                compareHabitsByDaysLeft statsOne statsTwo
-                        in
-                        if daysLeftComparison == EQ then
-                            let
-                                currentGoalProgressComparison =
-                                    compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo
-                            in
-                            if currentGoalProgressComparison == EQ then
-                                compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo
-                            else
-                                currentGoalProgressComparison
-                        else
-                            daysLeftComparison
-                    else
-                        completionComparison
+                    compareByAll
+                        [ compareHabitsByCompletion
+                        , compareHabitsByDaysLeft
+                        , compareHabitsByCurrentGoalProgress
+                        , compareHabitsByCurrentGoalRemaining
+                        ]
+                        ( habitOne, statsOne )
+                        ( habitTwo, statsTwo )
     in
-    List.sortWith compareHabits habits
+    List.sortWith compareHabitsByCurrentFragment habits

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -9,12 +9,15 @@ import Models.Habit as Habit
 
 isHabitCurrentFragmentSuccessful : Habit.Habit -> FrequencyStats.FrequencyStats -> Bool
 isHabitCurrentFragmentSuccessful habit frequencyStats =
-    case habit of
-        Habit.GoodHabit _ ->
-            frequencyStats.currentFragmentTotal >= frequencyStats.currentFragmentGoal
+    if not frequencyStats.habitHasStarted then
+        False
+    else
+        case habit of
+            Habit.GoodHabit _ ->
+                frequencyStats.currentFragmentTotal >= frequencyStats.currentFragmentGoal
 
-        Habit.BadHabit _ ->
-            frequencyStats.currentFragmentTotal <= frequencyStats.currentFragmentGoal
+            Habit.BadHabit _ ->
+                frequencyStats.currentFragmentTotal <= frequencyStats.currentFragmentGoal
 
 
 findFrequencyStatsForHabit : Habit.Habit -> List FrequencyStats.FrequencyStats -> Maybe FrequencyStats.FrequencyStats
@@ -52,6 +55,18 @@ compareByAll comparators tOne tTwo =
 
                 EQ ->
                     compareByAll restOfComparators tOne tTwo
+
+
+{-| Compares two habits by whether or not they have been started by the user.
+-}
+compareHabitsByHabitHasStarted : Comparator HabitStatsPair
+compareHabitsByHabitHasStarted ( _, statsOne ) ( _, statsTwo ) =
+    if statsOne.habitHasStarted == statsTwo.habitHasStarted then
+        EQ
+    else if statsOne.habitHasStarted then
+        GT
+    else
+        LT
 
 
 {-| Compares two habits by whether or not their current fragment goals have already been achieved. Prioritizes incomplete habits.
@@ -172,7 +187,8 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
 
                 ( Just statsOne, Just statsTwo ) ->
                     compareByAll
-                        [ compareHabitsByCompletion
+                        [ compareHabitsByHabitHasStarted
+                        , compareHabitsByCompletion
                         , compareHabitsByDaysLeft
                         , compareHabitsByCurrentGoalProgress
                         , compareHabitsByCurrentGoalRemaining

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -3,8 +3,8 @@ module HabitUtil exposing (..)
 {-| Module for useful Habit operations
 -}
 
-import Models.Habit as Habit
 import Models.FrequencyStats as FrequencyStats
+import Models.Habit as Habit
 
 
 isHabitCurrentFragmentSuccessful : Habit.Habit -> FrequencyStats.FrequencyStats -> Bool
@@ -21,20 +21,20 @@ findFrequencyStatsForHabit : Habit.Habit -> List FrequencyStats.FrequencyStats -
 findFrequencyStatsForHabit habit frequencyStats =
     let
         habitId =
-            (.id (Habit.getCommonFields habit))
+            .id (Habit.getCommonFields habit)
 
         filteredFrequencyStatsByHabitId =
             List.filter (\stats -> stats.habitId == habitId) frequencyStats
     in
-        case filteredFrequencyStatsByHabitId of
-            [] ->
-                Err ("No frequency stats found for habit " ++ habitId)
+    case filteredFrequencyStatsByHabitId of
+        [] ->
+            Err ("No frequency stats found for habit " ++ habitId)
 
-            [ s ] ->
-                Ok s
+        [ s ] ->
+            Ok s
 
-            s1 :: s2 :: _ ->
-                Err ("More than one frequency stats found for habit " ++ habitId ++ ", something fishy is going on")
+        s1 :: s2 :: _ ->
+            Err ("More than one frequency stats found for habit " ++ habitId ++ ", something fishy is going on")
 
 
 {-| Returns the habits sorted by completion, urgency, and current goal progress.
@@ -57,14 +57,14 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                 isHabitTwoGoalCompleted =
                     isHabitCurrentFragmentSuccessful habitTwo statsTwo
             in
-                if isHabitOneGoalCompleted == isHabitTwoGoalCompleted then
-                    EQ
-                else if isHabitOneGoalCompleted then
-                    -- habit one is already complete, habit two is not
-                    GT
-                else
-                    -- habit two is already complete, habit one is not
-                    LT
+            if isHabitOneGoalCompleted == isHabitTwoGoalCompleted then
+                EQ
+            else if isHabitOneGoalCompleted then
+                -- habit one is already complete, habit two is not
+                GT
+            else
+                -- habit two is already complete, habit one is not
+                LT
 
         --Compare habits by urgency: show urgent habits first
         compareHabitsByDaysLeft : FrequencyStats.FrequencyStats -> FrequencyStats.FrequencyStats -> Order
@@ -83,31 +83,30 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                 -- Progress relative to goal, e.g. 0.3 if the user has done 30% of the goal
                 getCurrentGoalProgressFraction : FrequencyStats.FrequencyStats -> Float
                 getCurrentGoalProgressFraction stats =
-                    ((toFloat stats.currentFragmentTotal)
-                        / (toFloat stats.currentFragmentGoal)
-                    )
+                    toFloat stats.currentFragmentTotal
+                        / toFloat stats.currentFragmentGoal
 
                 ( habitOneGoalProgressFraction, habitTwoGoalProgressFraction ) =
                     ( getCurrentGoalProgressFraction statsOne, getCurrentGoalProgressFraction statsTwo )
             in
-                case ( habitOne, habitTwo ) of
-                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
-                        -- The more progress the user has made, the less behind they are on
-                        -- the habit, so display it further down
-                        compare habitOneGoalProgressFraction habitTwoGoalProgressFraction
+            case ( habitOne, habitTwo ) of
+                ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+                    -- The more progress the user has made, the less behind they are on
+                    -- the habit, so display it further down
+                    compare habitOneGoalProgressFraction habitTwoGoalProgressFraction
 
-                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
-                        -- The more poorly the user has done, the more they should see it prominently
-                        -- displayed so they can be aware and work on it
-                        compare habitTwoGoalProgressFraction habitOneGoalProgressFraction
+                ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+                    -- The more poorly the user has done, the more they should see it prominently
+                    -- displayed so they can be aware and work on it
+                    compare habitTwoGoalProgressFraction habitOneGoalProgressFraction
 
-                    ( Habit.GoodHabit _, _ ) ->
-                        -- We probably shouldn't be sorting good habits and bad habits together,
-                        -- but if we are, we should display good habits first.
-                        LT
+                ( Habit.GoodHabit _, _ ) ->
+                    -- We probably shouldn't be sorting good habits and bad habits together,
+                    -- but if we are, we should display good habits first.
+                    LT
 
-                    _ ->
-                        GT
+                _ ->
+                    GT
 
         -- Compare habits by current goal remaining: Show habits that the user has more to do of first
         compareHabitsByCurrentGoalRemaining :
@@ -124,23 +123,23 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                 ( habitOneGoalRemaining, habitTwoGoalRemaining ) =
                     ( getCurrentGoalRemaining statsOne, getCurrentGoalRemaining statsTwo )
             in
-                case ( habitOne, habitTwo ) of
-                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
-                        -- The more there is left to do for habit one, the worse it is doing
-                        compare habitTwoGoalRemaining habitOneGoalRemaining
+            case ( habitOne, habitTwo ) of
+                ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+                    -- The more there is left to do for habit one, the worse it is doing
+                    compare habitTwoGoalRemaining habitOneGoalRemaining
 
-                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
-                        -- The bigger the difference between the goal and the total, the better
-                        -- the user is doing, the further down the list we should display the habit
-                        compare habitOneGoalRemaining habitTwoGoalRemaining
+                ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+                    -- The bigger the difference between the goal and the total, the better
+                    -- the user is doing, the further down the list we should display the habit
+                    compare habitOneGoalRemaining habitTwoGoalRemaining
 
-                    ( Habit.GoodHabit _, _ ) ->
-                        -- We probably shouldn't be sorting good habits and bad habits together,
-                        -- but if we are, we should display good habits first.
-                        LT
+                ( Habit.GoodHabit _, _ ) ->
+                    -- We probably shouldn't be sorting good habits and bad habits together,
+                    -- but if we are, we should display good habits first.
+                    LT
 
-                    _ ->
-                        GT
+                _ ->
+                    GT
 
         compareHabits : Habit.Habit -> Habit.Habit -> Order
         compareHabits habitOne habitTwo =
@@ -151,38 +150,38 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
                 habitTwoFrequencyStats =
                     findFrequencyStatsForHabit habitTwo frequencyStatsList
             in
-                case ( habitOneFrequencyStats, habitTwoFrequencyStats ) of
-                    ( Err _, Err _ ) ->
-                        EQ
+            case ( habitOneFrequencyStats, habitTwoFrequencyStats ) of
+                ( Err _, Err _ ) ->
+                    EQ
 
-                    ( Err _, Ok _ ) ->
-                        GT
+                ( Err _, Ok _ ) ->
+                    GT
 
-                    ( Ok _, Err _ ) ->
-                        LT
+                ( Ok _, Err _ ) ->
+                    LT
 
-                    ( Ok statsOne, Ok statsTwo ) ->
+                ( Ok statsOne, Ok statsTwo ) ->
+                    let
+                        completionComparison =
+                            compareHabitsByCompletion habitOne habitTwo statsOne statsTwo
+                    in
+                    if completionComparison == EQ then
                         let
-                            completionComparison =
-                                compareHabitsByCompletion habitOne habitTwo statsOne statsTwo
+                            daysLeftComparison =
+                                compareHabitsByDaysLeft statsOne statsTwo
                         in
-                            if completionComparison == EQ then
-                                let
-                                    daysLeftComparison =
-                                        compareHabitsByDaysLeft statsOne statsTwo
-                                in
-                                    if daysLeftComparison == EQ then
-                                        let
-                                            currentGoalProgressComparison =
-                                                compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo
-                                        in
-                                            if currentGoalProgressComparison == EQ then
-                                                compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo
-                                            else
-                                                currentGoalProgressComparison
-                                    else
-                                        daysLeftComparison
+                        if daysLeftComparison == EQ then
+                            let
+                                currentGoalProgressComparison =
+                                    compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo
+                            in
+                            if currentGoalProgressComparison == EQ then
+                                compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo
                             else
-                                completionComparison
+                                currentGoalProgressComparison
+                        else
+                            daysLeftComparison
+                    else
+                        completionComparison
     in
-        List.sortWith compareHabits habits
+    List.sortWith compareHabits habits

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -1,0 +1,83 @@
+module HabitUtil exposing (..)
+
+{-| Module for useful Habit operations
+-}
+
+import Models.Habit as Habit
+import Models.FrequencyStats as FrequencyStats
+
+
+isHabitCurrentFragmentSuccessful : Habit.Habit -> FrequencyStats.FrequencyStats -> Bool
+isHabitCurrentFragmentSuccessful habit frequencyStats =
+    case habit of
+        Habit.GoodHabit _ ->
+            frequencyStats.currentFragmentTotal >= frequencyStats.currentFragmentGoal
+
+        Habit.BadHabit _ ->
+            frequencyStats.currentFragmentTotal <= frequencyStats.currentFragmentGoal
+
+
+findFrequencyStatsForHabit : Habit.Habit -> List FrequencyStats.FrequencyStats -> Result String FrequencyStats.FrequencyStats
+findFrequencyStatsForHabit habit frequencyStats =
+    let
+        habitId =
+            (.id (Habit.getCommonFields habit))
+
+        filteredFrequencyStatsByHabitId =
+            List.filter (\stats -> stats.habitId == habitId) frequencyStats
+    in
+        case filteredFrequencyStatsByHabitId of
+            [] ->
+                Err ("No frequency stats found for habit " ++ habitId)
+
+            [ s ] ->
+                Ok s
+
+            s1 :: s2 :: _ ->
+                Err ("More than one frequency stats found for habit " ++ habitId ++ ", something fishy is going on")
+
+
+{-| Returns the habits sorted first by whether the current fragment goal has already been achieved
+(unfinished habits come first), and then by the number of days remaining in the current time fragment
+(more urgent habit goals come first).
+-}
+sortHabitsByCurrentFragment : List FrequencyStats.FrequencyStats -> List Habit.Habit -> List Habit.Habit
+sortHabitsByCurrentFragment frequencyStatsList habits =
+    let
+        compareHabits : Habit.Habit -> Habit.Habit -> Order
+        compareHabits habitOne habitTwo =
+            let
+                habitOneFrequencyStats =
+                    findFrequencyStatsForHabit habitOne frequencyStatsList
+
+                habitTwoFrequencyStats =
+                    findFrequencyStatsForHabit habitTwo frequencyStatsList
+            in
+                case ( habitOneFrequencyStats, habitTwoFrequencyStats ) of
+                    ( Err _, Err _ ) ->
+                        EQ
+
+                    ( Err _, Ok _ ) ->
+                        GT
+
+                    ( Ok _, Err _ ) ->
+                        LT
+
+                    ( Ok statsOne, Ok statsTwo ) ->
+                        let
+                            isHabitOneAlreadySuccessful =
+                                isHabitCurrentFragmentSuccessful habitOne statsOne
+
+                            isHabitTwoAlreadySuccessful =
+                                isHabitCurrentFragmentSuccessful habitTwo statsTwo
+                        in
+                            if isHabitOneAlreadySuccessful == isHabitTwoAlreadySuccessful then
+                                compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+                            else if isHabitOneAlreadySuccessful then
+                                -- We know they are different so if `isHabitOneAlreadySuccessful` is true
+                                -- then `isHabitTwoAlreadySuccessful` must be false
+                                GT
+                            else
+                                LT
+    in
+        List.sortWith compareHabits habits

--- a/web-client/src/HabitUtil.elm
+++ b/web-client/src/HabitUtil.elm
@@ -37,13 +37,111 @@ findFrequencyStatsForHabit habit frequencyStats =
                 Err ("More than one frequency stats found for habit " ++ habitId ++ ", something fishy is going on")
 
 
-{-| Returns the habits sorted first by whether the current fragment goal has already been achieved
-(unfinished habits come first), and then by the number of days remaining in the current time fragment
-(more urgent habit goals come first).
+{-| Returns the habits sorted by completion, urgency, and current goal progress.
 -}
 sortHabitsByCurrentFragment : List FrequencyStats.FrequencyStats -> List Habit.Habit -> List Habit.Habit
 sortHabitsByCurrentFragment frequencyStatsList habits =
     let
+        -- Compare habits by completion: show incomplete habits first
+        compareHabitsByCompletion :
+            Habit.Habit
+            -> Habit.Habit
+            -> FrequencyStats.FrequencyStats
+            -> FrequencyStats.FrequencyStats
+            -> Order
+        compareHabitsByCompletion habitOne habitTwo statsOne statsTwo =
+            let
+                isHabitOneGoalCompleted =
+                    isHabitCurrentFragmentSuccessful habitOne statsOne
+
+                isHabitTwoGoalCompleted =
+                    isHabitCurrentFragmentSuccessful habitTwo statsTwo
+            in
+                if isHabitOneGoalCompleted == isHabitTwoGoalCompleted then
+                    EQ
+                else if isHabitOneGoalCompleted then
+                    -- habit one is already complete, habit two is not
+                    GT
+                else
+                    -- habit two is already complete, habit one is not
+                    LT
+
+        --Compare habits by urgency: show urgent habits first
+        compareHabitsByDaysLeft : FrequencyStats.FrequencyStats -> FrequencyStats.FrequencyStats -> Order
+        compareHabitsByDaysLeft statsOne statsTwo =
+            compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+
+        --Compare habits by current goal progress: Show habits that the user is further behind on first
+        compareHabitsByCurrentGoalProgress :
+            Habit.Habit
+            -> Habit.Habit
+            -> FrequencyStats.FrequencyStats
+            -> FrequencyStats.FrequencyStats
+            -> Order
+        compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo =
+            let
+                -- Progress relative to goal, e.g. 0.3 if the user has done 30% of the goal
+                getCurrentGoalProgressFraction : FrequencyStats.FrequencyStats -> Float
+                getCurrentGoalProgressFraction stats =
+                    ((toFloat stats.currentFragmentTotal)
+                        / (toFloat stats.currentFragmentGoal)
+                    )
+
+                ( habitOneGoalProgressFraction, habitTwoGoalProgressFraction ) =
+                    ( getCurrentGoalProgressFraction statsOne, getCurrentGoalProgressFraction statsTwo )
+            in
+                case ( habitOne, habitTwo ) of
+                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+                        -- The more progress the user has made, the less behind they are on
+                        -- the habit, so display it further down
+                        compare habitOneGoalProgressFraction habitTwoGoalProgressFraction
+
+                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+                        -- The more poorly the user has done, the more they should see it prominently
+                        -- displayed so they can be aware and work on it
+                        compare habitTwoGoalProgressFraction habitOneGoalProgressFraction
+
+                    ( Habit.GoodHabit _, _ ) ->
+                        -- We probably shouldn't be sorting good habits and bad habits together,
+                        -- but if we are, we should display good habits first.
+                        LT
+
+                    _ ->
+                        GT
+
+        -- Compare habits by current goal remaining: Show habits that the user has more to do of first
+        compareHabitsByCurrentGoalRemaining :
+            Habit.Habit
+            -> Habit.Habit
+            -> FrequencyStats.FrequencyStats
+            -> FrequencyStats.FrequencyStats
+            -> Order
+        compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo =
+            let
+                getCurrentGoalRemaining stats =
+                    stats.currentFragmentGoal - stats.currentFragmentTotal
+
+                ( habitOneGoalRemaining, habitTwoGoalRemaining ) =
+                    ( getCurrentGoalRemaining statsOne, getCurrentGoalRemaining statsTwo )
+            in
+                case ( habitOne, habitTwo ) of
+                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
+                        -- The more there is left to do for habit one, the worse it is doing
+                        compare habitTwoGoalRemaining habitOneGoalRemaining
+
+                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
+                        -- The bigger the difference between the goal and the total, the better
+                        -- the user is doing, the further down the list we should display the habit
+                        compare habitOneGoalRemaining habitTwoGoalRemaining
+
+                    ( Habit.GoodHabit _, _ ) ->
+                        -- We probably shouldn't be sorting good habits and bad habits together,
+                        -- but if we are, we should display good habits first.
+                        LT
+
+                    _ ->
+                        GT
+
         compareHabits : Habit.Habit -> Habit.Habit -> Order
         compareHabits habitOne habitTwo =
             let
@@ -65,56 +163,26 @@ sortHabitsByCurrentFragment frequencyStatsList habits =
 
                     ( Ok statsOne, Ok statsTwo ) ->
                         let
-                            isHabitOneAlreadySuccessful =
-                                isHabitCurrentFragmentSuccessful habitOne statsOne
-
-                            isHabitTwoAlreadySuccessful =
-                                isHabitCurrentFragmentSuccessful habitTwo statsTwo
+                            completionComparison =
+                                compareHabitsByCompletion habitOne habitTwo statsOne statsTwo
                         in
-                            if isHabitOneAlreadySuccessful == isHabitTwoAlreadySuccessful then
+                            if completionComparison == EQ then
                                 let
                                     daysLeftComparison =
-                                        compare statsOne.currentFragmentDaysLeft statsTwo.currentFragmentDaysLeft
+                                        compareHabitsByDaysLeft statsOne statsTwo
                                 in
-                                    case daysLeftComparison of
-                                        EQ ->
-                                            -- further sort by current fragment progress
-                                            let
-                                                getCurrentProgress : FrequencyStats.FrequencyStats -> Float
-                                                getCurrentProgress stats =
-                                                    ((toFloat stats.currentFragmentTotal)
-                                                        / (toFloat stats.currentFragmentGoal)
-                                                    )
-
-                                                ( habitOneProgress, habitTwoProgress ) =
-                                                    ( getCurrentProgress statsOne, getCurrentProgress statsTwo )
-                                            in
-                                                case ( habitOne, habitTwo ) of
-                                                    ( Habit.GoodHabit _, Habit.GoodHabit _ ) ->
-                                                        -- The more progress the user has made, the less behind they are on
-                                                        -- the habit, so display it further down
-                                                        compare habitOneProgress habitTwoProgress
-
-                                                    ( Habit.BadHabit _, Habit.BadHabit _ ) ->
-                                                        -- The more poorly the user has done, the more they should see it prominently
-                                                        -- displayed so they can be aware and work on it
-                                                        compare habitTwoProgress habitOneProgress
-
-                                                    ( Habit.GoodHabit _, Habit.BadHabit _ ) ->
-                                                        -- We probably shouldn't be sorting good habits and bad habits together,
-                                                        -- but if we are, we should display good habits first.
-                                                        LT
-
-                                                    _ ->
-                                                        GT
-
-                                        _ ->
-                                            daysLeftComparison
-                            else if isHabitOneAlreadySuccessful then
-                                -- We know they are different so if `isHabitOneAlreadySuccessful` is true
-                                -- then `isHabitTwoAlreadySuccessful` must be false
-                                GT
+                                    if daysLeftComparison == EQ then
+                                        let
+                                            currentGoalProgressComparison =
+                                                compareHabitsByCurrentGoalProgress habitOne habitTwo statsOne statsTwo
+                                        in
+                                            if currentGoalProgressComparison == EQ then
+                                                compareHabitsByCurrentGoalRemaining habitOne habitTwo statsOne statsTwo
+                                            else
+                                                currentGoalProgressComparison
+                                    else
+                                        daysLeftComparison
                             else
-                                LT
+                                completionComparison
     in
         List.sortWith compareHabits habits

--- a/web-client/src/Init.elm
+++ b/web-client/src/Init.elm
@@ -30,6 +30,7 @@ init { apiBaseUrl, currentTime } location =
           , openHistoryViewer = False
           , historyViewerDateInput = ""
           , historyViewerSelectedDate = Nothing
+          , historyViewerFrequencyStats = RemoteData.NotAsked
           }
         , Api.queryHabitsAndHabitDataAndFrequencyStats
             ymd

--- a/web-client/src/Init.elm
+++ b/web-client/src/Init.elm
@@ -14,17 +14,26 @@ import RemoteData
 
 init : Flags -> Navigation.Location -> ( Model, Cmd Msg )
 init { apiBaseUrl, currentTime } location =
-    ( { ymd = currentTime |> Date.fromTime |> YmdDate.fromDate
-      , apiBaseUrl = apiBaseUrl
-      , editingTodayHabitAmount = Dict.empty
-      , editingHistoryHabitAmount = Dict.empty
-      , allHabitData = RemoteData.Loading
-      , allHabits = RemoteData.Loading
-      , addHabit = Habit.initAddHabitData
-      , openTodayViewer = True
-      , openHistoryViewer = False
-      , historyViewerDateInput = ""
-      , historyViewerSelectedDate = Nothing
-      }
-    , Api.queryHabitsAndHabitData apiBaseUrl OnGetHabitsAndHabitDataFailure OnGetHabitsAndHabitDataSuccess
-    )
+    let
+        ymd =
+            currentTime |> Date.fromTime |> YmdDate.fromDate
+    in
+        ( { ymd = ymd
+          , apiBaseUrl = apiBaseUrl
+          , editingTodayHabitAmount = Dict.empty
+          , editingHistoryHabitAmount = Dict.empty
+          , allHabitData = RemoteData.Loading
+          , allHabits = RemoteData.Loading
+          , allFrequencyStats = RemoteData.Loading
+          , addHabit = Habit.initAddHabitData
+          , openTodayViewer = True
+          , openHistoryViewer = False
+          , historyViewerDateInput = ""
+          , historyViewerSelectedDate = Nothing
+          }
+        , Api.queryHabitsAndHabitDataAndFrequencyStats
+            ymd
+            apiBaseUrl
+            OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+        )

--- a/web-client/src/Init.elm
+++ b/web-client/src/Init.elm
@@ -18,23 +18,23 @@ init { apiBaseUrl, currentTime } location =
         ymd =
             currentTime |> Date.fromTime |> YmdDate.fromDate
     in
-        ( { ymd = ymd
-          , apiBaseUrl = apiBaseUrl
-          , editingTodayHabitAmount = Dict.empty
-          , editingHistoryHabitAmount = Dict.empty
-          , allHabitData = RemoteData.Loading
-          , allHabits = RemoteData.Loading
-          , allFrequencyStats = RemoteData.Loading
-          , addHabit = Habit.initAddHabitData
-          , openTodayViewer = True
-          , openHistoryViewer = False
-          , historyViewerDateInput = ""
-          , historyViewerSelectedDate = Nothing
-          , historyViewerFrequencyStats = RemoteData.NotAsked
-          }
-        , Api.queryHabitsAndHabitDataAndFrequencyStats
-            ymd
-            apiBaseUrl
-            OnGetHabitsAndHabitDataAndFrequencyStatsFailure
-            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
-        )
+    ( { ymd = ymd
+      , apiBaseUrl = apiBaseUrl
+      , editingTodayHabitAmount = Dict.empty
+      , editingHistoryHabitAmount = Dict.empty
+      , allHabitData = RemoteData.Loading
+      , allHabits = RemoteData.Loading
+      , allFrequencyStats = RemoteData.Loading
+      , addHabit = Habit.initAddHabitData
+      , openTodayViewer = True
+      , openHistoryViewer = False
+      , historyViewerDateInput = ""
+      , historyViewerSelectedDate = Nothing
+      , historyViewerFrequencyStats = RemoteData.NotAsked
+      }
+    , Api.queryHabitsAndHabitDataAndFrequencyStats
+        ymd
+        apiBaseUrl
+        OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+        OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+    )

--- a/web-client/src/Model.elm
+++ b/web-client/src/Model.elm
@@ -2,9 +2,9 @@ module Model exposing (..)
 
 import Dict
 import Models.ApiError as ApiError
+import Models.FrequencyStats as FrequencyStats
 import Models.Habit as Habit
 import Models.HabitData as HabitData
-import Models.FrequencyStats as FrequencyStats
 import Models.YmdDate as YmdDate
 import RemoteData
 

--- a/web-client/src/Model.elm
+++ b/web-client/src/Model.elm
@@ -4,6 +4,7 @@ import Dict
 import Models.ApiError as ApiError
 import Models.Habit as Habit
 import Models.HabitData as HabitData
+import Models.FrequencyStats as FrequencyStats
 import Models.YmdDate as YmdDate
 import RemoteData
 
@@ -15,6 +16,7 @@ type alias Model =
     , editingHistoryHabitAmount : Dict.Dict String (Dict.Dict String Int)
     , allHabits : RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     , allHabitData : RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    , allFrequencyStats : RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     , addHabit :
         { openView : Bool
         , kind : Habit.HabitKind

--- a/web-client/src/Model.elm
+++ b/web-client/src/Model.elm
@@ -41,4 +41,5 @@ type alias Model =
     , openHistoryViewer : Bool
     , historyViewerDateInput : String
     , historyViewerSelectedDate : Maybe YmdDate.YmdDate
+    , historyViewerFrequencyStats : RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     }

--- a/web-client/src/Models/FrequencyStats.elm
+++ b/web-client/src/Models/FrequencyStats.elm
@@ -1,0 +1,31 @@
+module Models.FrequencyStats exposing (..)
+
+import Json.Decode as Decode exposing (null)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
+
+
+type alias FrequencyStats =
+    { habitId : String
+    , totalFragments : Int
+    , successfulFragments : Int
+    , totalDone : Int
+    , currentFragmentStreak : Int
+    , bestFragmentStreak : Int
+    , currentFragmentTotal : Int
+    , currentFragmentGoal : Int
+    , currentFragmentDaysLeft : Int
+    }
+
+
+decodeFrequencyStats : Decode.Decoder FrequencyStats
+decodeFrequencyStats =
+    decode FrequencyStats
+        |> required "habit_id" Decode.string
+        |> required "total_fragments" Decode.int
+        |> required "successful_fragments" Decode.int
+        |> required "total_done" Decode.int
+        |> required "current_fragment_streak" Decode.int
+        |> required "best_fragment_streak" Decode.int
+        |> required "current_fragment_total" Decode.int
+        |> required "current_fragment_goal" Decode.int
+        |> required "current_fragment_days_left" Decode.int

--- a/web-client/src/Models/FrequencyStats.elm
+++ b/web-client/src/Models/FrequencyStats.elm
@@ -14,6 +14,7 @@ type alias FrequencyStats =
     , currentFragmentTotal : Int
     , currentFragmentGoal : Int
     , currentFragmentDaysLeft : Int
+    , habitHasStarted : Bool
     }
 
 
@@ -29,3 +30,4 @@ decodeFrequencyStats =
         |> required "current_fragment_total" Decode.int
         |> required "current_fragment_goal" Decode.int
         |> required "current_fragment_days_left" Decode.int
+        |> required "habit_has_started" Decode.bool

--- a/web-client/src/Models/Habit.elm
+++ b/web-client/src/Models/Habit.elm
@@ -170,7 +170,7 @@ splitHabits habits =
                 )
                 habits
     in
-        ( goodHabits, badHabits )
+    ( goodHabits, badHabits )
 
 
 {-| Retrieve fields that exist on both good and bad habits.
@@ -291,22 +291,22 @@ extractCreateHabit addHabitInputData =
                         _ ->
                             Nothing
     in
-        case addHabitInputData.kind of
-            GoodHabitKind ->
-                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                        Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
+    case addHabitInputData.kind of
+        GoodHabitKind ->
+            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                    Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
 
-                    _ ->
-                        Nothing
+                _ ->
+                    Nothing
 
-            BadHabitKind ->
-                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                        Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
+        BadHabitKind ->
+            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                    Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
 
-                    _ ->
-                        Nothing
+                _ ->
+                    Nothing
 
 
 decodeHabit : Decode.Decoder Habit
@@ -333,19 +333,19 @@ decodeHabit =
                 |> required "unit_name_plural" Decode.string
                 |> required "threshold_frequency" decodeFrequency
     in
-        Decode.at [ "__typename" ] Decode.string
-            |> Decode.andThen
-                (\typeName ->
-                    case typeName of
-                        "good_habit" ->
-                            decodeGoodHabitRecord |> Decode.map GoodHabit
+    Decode.at [ "__typename" ] Decode.string
+        |> Decode.andThen
+            (\typeName ->
+                case typeName of
+                    "good_habit" ->
+                        decodeGoodHabitRecord |> Decode.map GoodHabit
 
-                        "bad_habit" ->
-                            decodeBadHabitRecord |> Decode.map BadHabit
+                    "bad_habit" ->
+                        decodeBadHabitRecord |> Decode.map BadHabit
 
-                        _ ->
-                            Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
-                )
+                    _ ->
+                        Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
+            )
 
 
 decodeFrequency : Decode.Decoder Frequency
@@ -369,22 +369,22 @@ decodeFrequency =
                 |> optional "saturday" Decode.int 0
                 |> optional "sunday" Decode.int 0
     in
-        Decode.at [ "__typename" ] Decode.string
-            |> Decode.andThen
-                (\typeName ->
-                    case typeName of
-                        "specific_day_of_week_frequency" ->
-                            decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
+    Decode.at [ "__typename" ] Decode.string
+        |> Decode.andThen
+            (\typeName ->
+                case typeName of
+                    "specific_day_of_week_frequency" ->
+                        decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
 
-                        "total_week_frequency" ->
-                            decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
+                    "total_week_frequency" ->
+                        decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
 
-                        "every_x_days_frequency" ->
-                            decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
+                    "every_x_days_frequency" ->
+                        decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
 
-                        _ ->
-                            Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
-                )
+                    _ ->
+                        Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
+            )
 
 
 decodeHabitTime : Decode.Decoder HabitTime
@@ -404,4 +404,4 @@ decodeHabitTime =
                 _ ->
                     Decode.fail <| str ++ " is not a valid habit time."
     in
-        Decode.string |> Decode.andThen fromStringDecoder
+    Decode.string |> Decode.andThen fromStringDecoder

--- a/web-client/src/Models/Habit.elm
+++ b/web-client/src/Models/Habit.elm
@@ -170,7 +170,7 @@ splitHabits habits =
                 )
                 habits
     in
-    ( goodHabits, badHabits )
+        ( goodHabits, badHabits )
 
 
 {-| Retrieve fields that exist on both good and bad habits.
@@ -291,22 +291,22 @@ extractCreateHabit addHabitInputData =
                         _ ->
                             Nothing
     in
-    case addHabitInputData.kind of
-        GoodHabitKind ->
-            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                    Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
+        case addHabitInputData.kind of
+            GoodHabitKind ->
+                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                        Just <| CreateGoodHabit <| CreateGoodHabitRecord name description goodHabitTime unitNameSingular unitNamePlural frequency
 
-                _ ->
-                    Nothing
+                    _ ->
+                        Nothing
 
-        BadHabitKind ->
-            case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
-                ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
-                    Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
+            BadHabitKind ->
+                case ( name, description, unitNameSingular, unitNamePlural, frequency ) of
+                    ( Just name, Just description, Just unitNameSingular, Just unitNamePlural, Just frequency ) ->
+                        Just <| CreateBadHabit <| CreateBadHabitRecord name description unitNameSingular unitNamePlural frequency
 
-                _ ->
-                    Nothing
+                    _ ->
+                        Nothing
 
 
 decodeHabit : Decode.Decoder Habit
@@ -333,19 +333,19 @@ decodeHabit =
                 |> required "unit_name_plural" Decode.string
                 |> required "threshold_frequency" decodeFrequency
     in
-    Decode.at [ "__typename" ] Decode.string
-        |> Decode.andThen
-            (\typeName ->
-                case typeName of
-                    "good_habit" ->
-                        decodeGoodHabitRecord |> Decode.map GoodHabit
+        Decode.at [ "__typename" ] Decode.string
+            |> Decode.andThen
+                (\typeName ->
+                    case typeName of
+                        "good_habit" ->
+                            decodeGoodHabitRecord |> Decode.map GoodHabit
 
-                    "bad_habit" ->
-                        decodeBadHabitRecord |> Decode.map BadHabit
+                        "bad_habit" ->
+                            decodeBadHabitRecord |> Decode.map BadHabit
 
-                    _ ->
-                        Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
-            )
+                        _ ->
+                            Decode.fail <| "Unable to decode habit, invalid __typename: " ++ typeName
+                )
 
 
 decodeFrequency : Decode.Decoder Frequency
@@ -369,22 +369,22 @@ decodeFrequency =
                 |> optional "saturday" Decode.int 0
                 |> optional "sunday" Decode.int 0
     in
-    Decode.at [ "__typename" ] Decode.string
-        |> Decode.andThen
-            (\typeName ->
-                case typeName of
-                    "specific_day_of_week_frequency" ->
-                        decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
+        Decode.at [ "__typename" ] Decode.string
+            |> Decode.andThen
+                (\typeName ->
+                    case typeName of
+                        "specific_day_of_week_frequency" ->
+                            decodeSpecificDayOfWeekFrequencyRecord |> Decode.map SpecificDayOfWeekFrequency
 
-                    "total_week_frequency" ->
-                        decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
+                        "total_week_frequency" ->
+                            decodeTotalWeekFrequencyRecord |> Decode.map TotalWeekFrequency
 
-                    "every_x_days_frequency" ->
-                        decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
+                        "every_x_days_frequency" ->
+                            decodeEveryXDayFrequencyRecord |> Decode.map EveryXDayFrequency
 
-                    _ ->
-                        Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
-            )
+                        _ ->
+                            Decode.fail <| "Unable to decode frequency, invalid __typename: " ++ typeName
+                )
 
 
 decodeHabitTime : Decode.Decoder HabitTime
@@ -404,4 +404,4 @@ decodeHabitTime =
                 _ ->
                     Decode.fail <| str ++ " is not a valid habit time."
     in
-    Decode.string |> Decode.andThen fromStringDecoder
+        Decode.string |> Decode.andThen fromStringDecoder

--- a/web-client/src/Msg.elm
+++ b/web-client/src/Msg.elm
@@ -13,8 +13,8 @@ type Msg
     = NoOp
     | OnLocationChange Navigation.Location
     | TickMinute Time.Time
-    | OnGetHabitsAndHabitDataFailure ApiError
-    | OnGetHabitsAndHabitDataSuccess Api.HabitsAndHabitData
+    | OnGetHabitsAndHabitDataAndFrequencyStatsFailure ApiError
+    | OnGetHabitsAndHabitDataAndFrequencyStatsSuccess Api.HabitsAndHabitDataAndFrequencyStats
     | OnOpenAddHabit
     | OnCancelAddHabit
     | OnSelectAddHabitKind Habit.HabitKind

--- a/web-client/src/Msg.elm
+++ b/web-client/src/Msg.elm
@@ -48,7 +48,6 @@ type Msg
     | OnHistoryViewerSelectBeforeYesterday
     | OnHistoryViewerSelectDateInput
     | SetHistoryViewerSelectedDate YmdDate.YmdDate
-    | GetHistoryViewerFrequencyStats
     | OnGetPastFrequencyStatsFailure ApiError
     | OnGetPastFrequencyStatsSuccess Api.QueriedFrequencyStats
     | OnHistoryViewerChangeDate

--- a/web-client/src/Msg.elm
+++ b/web-client/src/Msg.elm
@@ -47,5 +47,9 @@ type Msg
     | OnHistoryViewerSelectYesterday
     | OnHistoryViewerSelectBeforeYesterday
     | OnHistoryViewerSelectDateInput
+    | SetHistoryViewerSelectedDate YmdDate.YmdDate
+    | GetHistoryViewerFrequencyStats
+    | OnGetPastFrequencyStatsFailure ApiError
+    | OnGetPastFrequencyStatsSuccess Api.QueriedFrequencyStats
     | OnHistoryViewerChangeDate
     | OnHistoryViewerHabitDataInput YmdDate.YmdDate String String

--- a/web-client/src/Styles/global.scss
+++ b/web-client/src/Styles/global.scss
@@ -279,6 +279,37 @@
 
             .habit-name {
                 font-weight: 600;
+                width: 150px;
+                float: left;
+            }
+
+            .frequency-stats {
+                margin-left: 10px;
+                text-overflow: ellipsis;
+                font-weight: 200;
+                font-size: 12px;
+                color: blue;
+                text-align: right;
+                float: right;
+                .frequency-statistic{
+                  width: 130px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  font-style: italic;
+                }
+                .frequency-stats-title {
+                  font-weight: 600;
+                  text-decoration: underline;
+                }
+                .current-fragment-success {
+                  color: green;
+                  font-weight: 500;
+                }
+                .current-fragment-failure {
+                  color: #802200;  // dark red text
+                  font-weight: 500;
+                }
             }
 
             .habit-amount-complete {
@@ -286,7 +317,7 @@
                 position: absolute;
                 bottom: 7px;
                 border: none;
-                width: 200px;
+                width: 160px;
 
                 input  {
                     box-sizing: border-box;

--- a/web-client/src/Styles/global.scss
+++ b/web-client/src/Styles/global.scss
@@ -253,16 +253,49 @@
         margin-top: -5px;
 
         &.good-habits {
-            .habit {
-                background-color: #45d893;
-                border: 1px solid #42b36e;
+            .habit-success {
+                background-color: rgba(14, 238, 70, 0.59);
+                border: 1px solid rgba(100, 182, 120, 1);
+                .frequency-statistic {
+                    color: rgb(16, 147, 0);
+                }
+                .current-progress {
+                    color: rgb(35, 126, 27);
+                }
+            }
+            .habit-failure {
+                background-color: rgb(132, 132, 231);
+                border: 1px solid rgb(93, 93, 230);
+                .frequency-statistic {
+                    color: rgb(79, 79, 79);
+                }
+                .current-progress {
+                    color: rgb(66, 66, 66);
+                }
             }
         }
 
         &.bad-habits {
-            .habit {
+            .habit-success {
                 background-color: #ffc971;
-                border: 1px solid #ffb627;
+                border: 1px solid #e9b155;
+                .frequency-statistic {
+                    color: rgb(91, 79, 0);
+                }
+                .current-progress {
+                    color: rgb(99, 84, 0);
+                }
+            }
+            .habit-failure {
+                background-color: rgb(203, 68, 68);
+                border: rgb(153, 0, 0);
+                .frequency-statistic {
+                  color: rgb(32, 0, 0);
+                }
+                .current-progress {
+                    color: rgb(56, 0, 0);
+                    font-weight: 700;
+                }
             }
         }
 
@@ -283,33 +316,24 @@
                 float: left;
             }
 
-            .frequency-stats {
+            .frequency-stats-list {
+                float: right;
+            }
+
+            .frequency-statistic {
                 margin-left: 10px;
-                text-overflow: ellipsis;
+                width: 130px;
                 font-weight: 200;
                 font-size: 12px;
-                color: blue;
                 text-align: right;
-                float: right;
-                .frequency-statistic{
-                  width: 130px;
-                  white-space: nowrap;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  font-style: italic;
-                }
-                .frequency-stats-title {
-                  font-weight: 600;
-                  text-decoration: underline;
-                }
-                .current-fragment-success {
-                  color: green;
-                  font-weight: 500;
-                }
-                .current-fragment-failure {
-                  color: #802200;  // dark red text
-                  font-weight: 500;
-                }
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+
+            .current-progress {
+                @extend .frequency-statistic;
+                font-weight: 600;
             }
 
             .habit-amount-complete {
@@ -350,6 +374,13 @@
                     }
                 }
             }
+        }
+
+        .habit-success {
+            @extend .habit;
+        }
+        .habit-failure {
+            @extend .habit;
         }
     }
 }

--- a/web-client/src/Update.elm
+++ b/web-client/src/Update.elm
@@ -43,7 +43,14 @@ update msg model =
                 ( model, Cmd.none )
 
             TickMinute time ->
-                ( { model | ymd = time |> Date.fromTime |> YmdDate.fromDate }, Cmd.none )
+                let
+                    newYmd =
+                        time |> Date.fromTime |> YmdDate.fromDate
+                in
+                    if model.ymd /= newYmd then
+                        ( { model | ymd = newYmd }, getHabitsAndHabitDataAndFrequencyStats )
+                    else
+                        ( model, Cmd.none )
 
             OnGetHabitsAndHabitDataAndFrequencyStatsFailure apiError ->
                 ( { model

--- a/web-client/src/Update.elm
+++ b/web-client/src/Update.elm
@@ -48,7 +48,13 @@ update msg model =
                         time |> Date.fromTime |> YmdDate.fromDate
                 in
                     if model.ymd /= newYmd then
-                        ( { model | ymd = newYmd }, getHabitsAndHabitDataAndFrequencyStats )
+                        ( { model | ymd = newYmd }
+                        , Api.queryHabitsAndHabitDataAndFrequencyStats
+                            newYmd
+                            model.apiBaseUrl
+                            OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+                            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+                        )
                     else
                         ( model, Cmd.none )
 

--- a/web-client/src/Update.elm
+++ b/web-client/src/Update.elm
@@ -18,251 +18,257 @@ update msg model =
         updateAddHabit updater =
             { model | addHabit = updater model.addHabit }
     in
-    case msg of
-        NoOp ->
-            ( model, Cmd.none )
+        case msg of
+            NoOp ->
+                ( model, Cmd.none )
 
-        OnLocationChange location ->
-            -- TODO
-            ( model, Cmd.none )
+            OnLocationChange location ->
+                -- TODO
+                ( model, Cmd.none )
 
-        TickMinute time ->
-            ( { model | ymd = time |> Date.fromTime |> YmdDate.fromDate }, Cmd.none )
+            TickMinute time ->
+                ( { model | ymd = time |> Date.fromTime |> YmdDate.fromDate }, Cmd.none )
 
-        OnGetHabitsAndHabitDataFailure apiError ->
-            ( { model
-                | allHabits = RemoteData.Failure apiError
-                , allHabitData = RemoteData.Failure apiError
-              }
-            , Cmd.none
-            )
+            OnGetHabitsAndHabitDataAndFrequencyStatsFailure apiError ->
+                ( { model
+                    | allHabits = RemoteData.Failure apiError
+                    , allHabitData = RemoteData.Failure apiError
+                    , allFrequencyStats = RemoteData.Failure apiError
+                  }
+                , Cmd.none
+                )
 
-        OnGetHabitsAndHabitDataSuccess { habits, habitData } ->
-            ( { model
-                | allHabits = RemoteData.Success habits
-                , allHabitData = RemoteData.Success habitData
-              }
-            , Cmd.none
-            )
+            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess { habits, habitData, frequencyStatsList } ->
+                ( { model
+                    | allHabits = RemoteData.Success habits
+                    , allHabitData = RemoteData.Success habitData
+                    , allFrequencyStats = RemoteData.Success frequencyStatsList
+                  }
+                , Cmd.none
+                )
 
-        OnOpenAddHabit ->
-            ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
+            OnOpenAddHabit ->
+                ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
 
-        OnCancelAddHabit ->
-            ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
+            OnCancelAddHabit ->
+                ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
 
-        OnSelectAddHabitKind habitKind ->
-            ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
+            OnSelectAddHabitKind habitKind ->
+                ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
 
-        OnAddHabitNameInput habitName ->
-            ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
+            OnAddHabitNameInput habitName ->
+                ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
 
-        OnAddHabitDescriptionInput habitDescription ->
-            ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
+            OnAddHabitDescriptionInput habitDescription ->
+                ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
 
-        OnSelectAddGoodHabitTime goodHabitTime ->
-            ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
+            OnSelectAddGoodHabitTime goodHabitTime ->
+                ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
 
-        OnAddHabitUnitNameSingularInput unitNameSingular ->
-            ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
+            OnAddHabitUnitNameSingularInput unitNameSingular ->
+                ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
 
-        OnAddHabitUnitNamePluralInput unitNamePlural ->
-            ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
+            OnAddHabitUnitNamePluralInput unitNamePlural ->
+                ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
 
-        OnAddHabitSelectFrequencyKind frequencyKind ->
-            ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
+            OnAddHabitSelectFrequencyKind frequencyKind ->
+                ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
 
-        OnAddHabitTimesPerWeekInput timesPerWeek ->
-            ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
-            , Cmd.none
-            )
+            OnAddHabitTimesPerWeekInput timesPerWeek ->
+                ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayMondayInput mondayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayMondayInput mondayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayThursdayInput thursdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayThursdayInput thursdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDayFridayInput fridayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDayFridayInput fridayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitSpecificDaySundayInput sundayTimes ->
-            ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
-            , Cmd.none
-            )
+            OnAddHabitSpecificDaySundayInput sundayTimes ->
+                ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
+                , Cmd.none
+                )
 
-        OnAddHabitTimesInput times ->
-            ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
-            , Cmd.none
-            )
+            OnAddHabitTimesInput times ->
+                ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
+                , Cmd.none
+                )
 
-        OnAddHabitDaysInput days ->
-            ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
-            , Cmd.none
-            )
+            OnAddHabitDaysInput days ->
+                ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
+                , Cmd.none
+                )
 
-        AddHabit createHabitData ->
-            ( model
-            , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
-            )
+            AddHabit createHabitData ->
+                ( model
+                , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
+                )
 
-        OnAddHabitFailure apiError ->
-            -- TODO
-            ( model, Cmd.none )
+            OnAddHabitFailure apiError ->
+                -- TODO
+                ( model, Cmd.none )
 
-        OnAddHabitSuccess habit ->
-            ( { model
-                | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
-                , addHabit = Habit.initAddHabitData
-              }
-            , Cmd.none
-            )
+            OnAddHabitSuccess habit ->
+                ( { model
+                    | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
+                    , addHabit = Habit.initAddHabitData
+                  }
+                , Cmd.none
+                )
 
-        OnHabitDataInput habitID newVal ->
-            let
-                newEditingTodayHabitAmount amount =
-                    model.editingTodayHabitAmount
-                        |> Dict.update habitID (always <| amount)
-            in
-            if String.isEmpty newVal then
-                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
-            else
-                case String.toInt newVal of
-                    Result.Err _ ->
+            OnHabitDataInput habitID newVal ->
+                let
+                    newEditingTodayHabitAmount amount =
+                        model.editingTodayHabitAmount
+                            |> Dict.update habitID (always <| amount)
+                in
+                    if String.isEmpty newVal then
+                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
+                    else
+                        case String.toInt newVal of
+                            Result.Err _ ->
+                                ( model, Cmd.none )
+
+                            Result.Ok newInt ->
+                                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
+
+            SetHabitData ymd habitId newVal ->
+                case newVal of
+                    Nothing ->
                         ( model, Cmd.none )
 
-                    Result.Ok newInt ->
-                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
+                    Just newVal ->
+                        ( model
+                        , Api.mutationSetHabitData
+                            ymd
+                            habitId
+                            newVal
+                            model.apiBaseUrl
+                            OnSetHabitDataFailure
+                            OnSetHabitDataSuccess
+                        )
 
-        SetHabitData ymd habitId newVal ->
-            case newVal of
-                Nothing ->
-                    ( model, Cmd.none )
+            OnSetHabitDataFailure apiError ->
+                -- TODO
+                ( model, Cmd.none )
 
-                Just newVal ->
-                    ( model
-                    , Api.mutationSetHabitData
-                        ymd
-                        habitId
-                        newVal
-                        model.apiBaseUrl
-                        OnSetHabitDataFailure
-                        OnSetHabitDataSuccess
+            OnSetHabitDataSuccess updatedHabitDatum ->
+                ( { model
+                    | allHabitData =
+                        RemoteData.map
+                            (\allHabitData ->
+                                Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
+                            )
+                            model.allHabitData
+                    , editingTodayHabitAmount =
+                        Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
+                    , editingHistoryHabitAmount =
+                        Dict.update
+                            (YmdDate.toSimpleString updatedHabitDatum.date)
+                            (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
+                            model.editingHistoryHabitAmount
+                  }
+                , Api.queryHabitsAndHabitDataAndFrequencyStats
+                    model.ymd
+                    model.apiBaseUrl
+                    OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+                    OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+                )
+
+            OnToggleHistoryViewer ->
+                ( { model | openHistoryViewer = not model.openHistoryViewer }
+                , Cmd.none
+                )
+
+            OnToggleTodayViewer ->
+                ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
+
+            OnHistoryViewerDateInput newDateInput ->
+                ( { model
+                    | historyViewerDateInput =
+                        newDateInput
+                            |> String.filter
+                                (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
+                  }
+                , Cmd.none
+                )
+
+            OnHistoryViewerSelectYesterday ->
+                let
+                    yesterday =
+                        YmdDate.addDays -1 model.ymd
+                in
+                    ( { model | historyViewerSelectedDate = Just yesterday }, Cmd.none )
+
+            OnHistoryViewerSelectBeforeYesterday ->
+                let
+                    beforeYesterday =
+                        YmdDate.addDays -2 model.ymd
+                in
+                    ( { model | historyViewerSelectedDate = Just beforeYesterday }
+                    , Cmd.none
                     )
 
-        OnSetHabitDataFailure apiError ->
-            -- TODO
-            ( model, Cmd.none )
-
-        OnSetHabitDataSuccess updatedHabitDatum ->
-            ( { model
-                | allHabitData =
-                    RemoteData.map
-                        (\allHabitData ->
-                            Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
+            OnHistoryViewerSelectDateInput ->
+                model.historyViewerDateInput
+                    |> YmdDate.fromSimpleString
+                    ||> (\ymd ->
+                            ( { model | historyViewerSelectedDate = Just ymd }
+                            , Cmd.none
+                            )
                         )
-                        model.allHabitData
-                , editingTodayHabitAmount =
-                    Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
-                , editingHistoryHabitAmount =
-                    Dict.update
-                        (YmdDate.toSimpleString updatedHabitDatum.date)
-                        (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
+                    ?> ( model, Cmd.none )
+
+            OnHistoryViewerChangeDate ->
+                ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
+
+            OnHistoryViewerHabitDataInput forDate habitId newInput ->
+                let
+                    editingHabitDataDict =
                         model.editingHistoryHabitAmount
-              }
-            , Cmd.none
-            )
+                            |> Dict.get (YmdDate.toSimpleString forDate)
+                            ?> Dict.empty
 
-        OnToggleHistoryViewer ->
-            ( { model | openHistoryViewer = not model.openHistoryViewer }
-            , Cmd.none
-            )
+                    newAmount =
+                        extractInt newInput (Dict.get habitId editingHabitDataDict)
 
-        OnToggleTodayViewer ->
-            ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
-
-        OnHistoryViewerDateInput newDateInput ->
-            ( { model
-                | historyViewerDateInput =
-                    newDateInput
-                        |> String.filter
-                            (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
-              }
-            , Cmd.none
-            )
-
-        OnHistoryViewerSelectYesterday ->
-            let
-                yesterday =
-                    YmdDate.addDays -1 model.ymd
-            in
-            ( { model | historyViewerSelectedDate = Just yesterday }, Cmd.none )
-
-        OnHistoryViewerSelectBeforeYesterday ->
-            let
-                beforeYesterday =
-                    YmdDate.addDays -2 model.ymd
-            in
-            ( { model | historyViewerSelectedDate = Just beforeYesterday }
-            , Cmd.none
-            )
-
-        OnHistoryViewerSelectDateInput ->
-            model.historyViewerDateInput
-                |> YmdDate.fromSimpleString
-                ||> (\ymd ->
-                        ( { model | historyViewerSelectedDate = Just ymd }
-                        , Cmd.none
-                        )
+                    updatedEditingHabitDataDict =
+                        editingHabitDataDict |> Dict.update habitId (always newAmount)
+                in
+                    ( { model
+                        | editingHistoryHabitAmount =
+                            model.editingHistoryHabitAmount
+                                |> Dict.update
+                                    (YmdDate.toSimpleString forDate)
+                                    (always <| Just updatedEditingHabitDataDict)
+                      }
+                    , Cmd.none
                     )
-                ?> ( model, Cmd.none )
-
-        OnHistoryViewerChangeDate ->
-            ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
-
-        OnHistoryViewerHabitDataInput forDate habitId newInput ->
-            let
-                editingHabitDataDict =
-                    model.editingHistoryHabitAmount
-                        |> Dict.get (YmdDate.toSimpleString forDate)
-                        ?> Dict.empty
-
-                newAmount =
-                    extractInt newInput (Dict.get habitId editingHabitDataDict)
-
-                updatedEditingHabitDataDict =
-                    editingHabitDataDict |> Dict.update habitId (always newAmount)
-            in
-            ( { model
-                | editingHistoryHabitAmount =
-                    model.editingHistoryHabitAmount
-                        |> Dict.update
-                            (YmdDate.toSimpleString forDate)
-                            (always <| Just updatedEditingHabitDataDict)
-              }
-            , Cmd.none
-            )
 
 
 extractInt : String -> Maybe Int -> Maybe Int

--- a/web-client/src/Update.elm
+++ b/web-client/src/Update.elm
@@ -34,288 +34,286 @@ update msg model =
                 OnGetPastFrequencyStatsFailure
                 OnGetPastFrequencyStatsSuccess
     in
-        case msg of
-            NoOp ->
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+        OnLocationChange location ->
+            -- TODO
+            ( model, Cmd.none )
+
+        TickMinute time ->
+            let
+                newYmd =
+                    time |> Date.fromTime |> YmdDate.fromDate
+            in
+            if model.ymd /= newYmd then
+                ( { model | ymd = newYmd }
+                , Api.queryHabitsAndHabitDataAndFrequencyStats
+                    newYmd
+                    model.apiBaseUrl
+                    OnGetHabitsAndHabitDataAndFrequencyStatsFailure
+                    OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
+                )
+            else
                 ( model, Cmd.none )
 
-            OnLocationChange location ->
-                -- TODO
-                ( model, Cmd.none )
+        OnGetHabitsAndHabitDataAndFrequencyStatsFailure apiError ->
+            ( { model
+                | allHabits = RemoteData.Failure apiError
+                , allHabitData = RemoteData.Failure apiError
+                , allFrequencyStats = RemoteData.Failure apiError
+              }
+            , Cmd.none
+            )
 
-            TickMinute time ->
-                let
-                    newYmd =
-                        time |> Date.fromTime |> YmdDate.fromDate
-                in
-                    if model.ymd /= newYmd then
-                        ( { model | ymd = newYmd }
-                        , Api.queryHabitsAndHabitDataAndFrequencyStats
-                            newYmd
-                            model.apiBaseUrl
-                            OnGetHabitsAndHabitDataAndFrequencyStatsFailure
-                            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess
-                        )
-                    else
+        OnGetHabitsAndHabitDataAndFrequencyStatsSuccess { habits, habitData, frequencyStatsList } ->
+            ( { model
+                | allHabits = RemoteData.Success habits
+                , allHabitData = RemoteData.Success habitData
+                , allFrequencyStats = RemoteData.Success frequencyStatsList
+              }
+            , Cmd.none
+            )
+
+        OnOpenAddHabit ->
+            ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
+
+        OnCancelAddHabit ->
+            ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
+
+        OnSelectAddHabitKind habitKind ->
+            ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
+
+        OnAddHabitNameInput habitName ->
+            ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
+
+        OnAddHabitDescriptionInput habitDescription ->
+            ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
+
+        OnSelectAddGoodHabitTime goodHabitTime ->
+            ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
+
+        OnAddHabitUnitNameSingularInput unitNameSingular ->
+            ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
+
+        OnAddHabitUnitNamePluralInput unitNamePlural ->
+            ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
+
+        OnAddHabitSelectFrequencyKind frequencyKind ->
+            ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
+
+        OnAddHabitTimesPerWeekInput timesPerWeek ->
+            ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDayMondayInput mondayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDayThursdayInput thursdayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDayFridayInput fridayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitSpecificDaySundayInput sundayTimes ->
+            ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
+            , Cmd.none
+            )
+
+        OnAddHabitTimesInput times ->
+            ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
+            , Cmd.none
+            )
+
+        OnAddHabitDaysInput days ->
+            ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
+            , Cmd.none
+            )
+
+        AddHabit createHabitData ->
+            ( model
+            , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
+            )
+
+        OnAddHabitFailure apiError ->
+            -- TODO
+            ( model, Cmd.none )
+
+        OnAddHabitSuccess habit ->
+            ( { model
+                | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
+                , addHabit = Habit.initAddHabitData
+              }
+            , Cmd.none
+            )
+
+        OnHabitDataInput habitID newVal ->
+            let
+                newEditingTodayHabitAmount amount =
+                    model.editingTodayHabitAmount
+                        |> Dict.update habitID (always <| amount)
+            in
+            if String.isEmpty newVal then
+                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
+            else
+                case String.toInt newVal of
+                    Result.Err _ ->
                         ( model, Cmd.none )
 
-            OnGetHabitsAndHabitDataAndFrequencyStatsFailure apiError ->
-                ( { model
-                    | allHabits = RemoteData.Failure apiError
-                    , allHabitData = RemoteData.Failure apiError
-                    , allFrequencyStats = RemoteData.Failure apiError
-                  }
-                , Cmd.none
-                )
+                    Result.Ok newInt ->
+                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
 
-            OnGetHabitsAndHabitDataAndFrequencyStatsSuccess { habits, habitData, frequencyStatsList } ->
-                ( { model
-                    | allHabits = RemoteData.Success habits
-                    , allHabitData = RemoteData.Success habitData
-                    , allFrequencyStats = RemoteData.Success frequencyStatsList
-                  }
-                , Cmd.none
-                )
+        SetHabitData ymd habitId newVal ->
+            case newVal of
+                Nothing ->
+                    ( model, Cmd.none )
 
-            OnOpenAddHabit ->
-                ( updateAddHabit (\addHabit -> { addHabit | openView = True }), Cmd.none )
+                Just newVal ->
+                    ( model
+                    , Api.mutationSetHabitData
+                        ymd
+                        habitId
+                        newVal
+                        model.apiBaseUrl
+                        OnSetHabitDataFailure
+                        OnSetHabitDataSuccess
+                    )
 
-            OnCancelAddHabit ->
-                ( updateAddHabit (\addHabit -> { addHabit | openView = False }), Cmd.none )
+        OnSetHabitDataFailure apiError ->
+            -- TODO
+            ( model, Cmd.none )
 
-            OnSelectAddHabitKind habitKind ->
-                ( updateAddHabit (\addHabit -> { addHabit | kind = habitKind }), Cmd.none )
-
-            OnAddHabitNameInput habitName ->
-                ( updateAddHabit (\addHabit -> { addHabit | name = habitName }), Cmd.none )
-
-            OnAddHabitDescriptionInput habitDescription ->
-                ( updateAddHabit (\addHabit -> { addHabit | description = habitDescription }), Cmd.none )
-
-            OnSelectAddGoodHabitTime goodHabitTime ->
-                ( updateAddHabit (\addHabit -> { addHabit | goodHabitTime = goodHabitTime }), Cmd.none )
-
-            OnAddHabitUnitNameSingularInput unitNameSingular ->
-                ( updateAddHabit (\addHabit -> { addHabit | unitNameSingular = unitNameSingular }), Cmd.none )
-
-            OnAddHabitUnitNamePluralInput unitNamePlural ->
-                ( updateAddHabit (\addHabit -> { addHabit | unitNamePlural = unitNamePlural }), Cmd.none )
-
-            OnAddHabitSelectFrequencyKind frequencyKind ->
-                ( updateAddHabit (\addHabit -> { addHabit | frequencyKind = frequencyKind }), Cmd.none )
-
-            OnAddHabitTimesPerWeekInput timesPerWeek ->
-                ( updateAddHabit (\addHabit -> { addHabit | timesPerWeek = extractInt timesPerWeek addHabit.timesPerWeek })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDayMondayInput mondayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | mondayTimes = extractInt mondayTimes addHabit.mondayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDayTuesdayInput tuesdayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | tuesdayTimes = extractInt tuesdayTimes addHabit.tuesdayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDayWednesdayInput wednesdayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | wednesdayTimes = extractInt wednesdayTimes addHabit.wednesdayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDayThursdayInput thursdayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | thursdayTimes = extractInt thursdayTimes addHabit.thursdayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDayFridayInput fridayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | fridayTimes = extractInt fridayTimes addHabit.fridayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDaySaturdayInput saturdayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | saturdayTimes = extractInt saturdayTimes addHabit.saturdayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitSpecificDaySundayInput sundayTimes ->
-                ( updateAddHabit (\addHabit -> { addHabit | sundayTimes = extractInt sundayTimes addHabit.sundayTimes })
-                , Cmd.none
-                )
-
-            OnAddHabitTimesInput times ->
-                ( updateAddHabit (\addHabit -> { addHabit | times = extractInt times addHabit.times })
-                , Cmd.none
-                )
-
-            OnAddHabitDaysInput days ->
-                ( updateAddHabit (\addHabit -> { addHabit | days = extractInt days addHabit.days })
-                , Cmd.none
-                )
-
-            AddHabit createHabitData ->
-                ( model
-                , Api.mutationAddHabit createHabitData model.apiBaseUrl OnAddHabitFailure OnAddHabitSuccess
-                )
-
-            OnAddHabitFailure apiError ->
-                -- TODO
-                ( model, Cmd.none )
-
-            OnAddHabitSuccess habit ->
-                ( { model
-                    | allHabits = RemoteData.map (\allHabits -> allHabits ++ [ habit ]) model.allHabits
-                    , addHabit = Habit.initAddHabitData
-                  }
-                , Cmd.none
-                )
-
-            OnHabitDataInput habitID newVal ->
-                let
-                    newEditingTodayHabitAmount amount =
-                        model.editingTodayHabitAmount
-                            |> Dict.update habitID (always <| amount)
-                in
-                    if String.isEmpty newVal then
-                        ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount Nothing }, Cmd.none )
-                    else
-                        case String.toInt newVal of
-                            Result.Err _ ->
-                                ( model, Cmd.none )
-
-                            Result.Ok newInt ->
-                                ( { model | editingTodayHabitAmount = newEditingTodayHabitAmount <| Just newInt }, Cmd.none )
-
-            SetHabitData ymd habitId newVal ->
-                case newVal of
-                    Nothing ->
-                        ( model, Cmd.none )
-
-                    Just newVal ->
-                        ( model
-                        , Api.mutationSetHabitData
-                            ymd
-                            habitId
-                            newVal
-                            model.apiBaseUrl
-                            OnSetHabitDataFailure
-                            OnSetHabitDataSuccess
-                        )
-
-            OnSetHabitDataFailure apiError ->
-                -- TODO
-                ( model, Cmd.none )
-
-            OnSetHabitDataSuccess updatedHabitDatum ->
-                let
-                    newModel =
-                        { model
-                            | allHabitData =
-                                RemoteData.map
-                                    (\allHabitData ->
-                                        Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
-                                    )
-                                    model.allHabitData
-                            , editingTodayHabitAmount =
-                                Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
-                            , editingHistoryHabitAmount =
-                                Dict.update
-                                    (YmdDate.toSimpleString updatedHabitDatum.date)
-                                    (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
-                                    model.editingHistoryHabitAmount
-                        }
-                in
-                    newModel
-                        ! [ getHabitsAndHabitDataAndFrequencyStats
-                          , (case newModel.historyViewerSelectedDate of
-                                Just ymd ->
-                                    getHistoryViewerFrequencyStats ymd
-
-                                Nothing ->
-                                    Cmd.none
-                            )
-                          ]
-
-            OnToggleHistoryViewer ->
-                ( { model | openHistoryViewer = not model.openHistoryViewer }
-                , Cmd.none
-                )
-
-            OnToggleTodayViewer ->
-                ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
-
-            OnHistoryViewerDateInput newDateInput ->
-                ( { model
-                    | historyViewerDateInput =
-                        newDateInput
-                            |> String.filter
-                                (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
-                  }
-                , Cmd.none
-                )
-
-            OnHistoryViewerSelectYesterday ->
-                let
-                    yesterday =
-                        YmdDate.addDays -1 model.ymd
-                in
-                    update (SetHistoryViewerSelectedDate yesterday) model
-
-            OnHistoryViewerSelectBeforeYesterday ->
-                let
-                    beforeYesterday =
-                        YmdDate.addDays -2 model.ymd
-                in
-                    update (SetHistoryViewerSelectedDate beforeYesterday) model
-
-            OnHistoryViewerSelectDateInput ->
-                let
-                    ymd =
-                        YmdDate.fromSimpleString model.historyViewerDateInput
-                in
-                    (case ymd of
+        OnSetHabitDataSuccess updatedHabitDatum ->
+            let
+                newModel =
+                    { model
+                        | allHabitData =
+                            RemoteData.map
+                                (\allHabitData ->
+                                    Util.replaceOrAdd allHabitData (.id >> (==) updatedHabitDatum.id) updatedHabitDatum
+                                )
+                                model.allHabitData
+                        , editingTodayHabitAmount =
+                            Dict.update updatedHabitDatum.habitId (always Nothing) model.editingTodayHabitAmount
+                        , editingHistoryHabitAmount =
+                            Dict.update
+                                (YmdDate.toSimpleString updatedHabitDatum.date)
+                                (Maybe.map (Dict.update updatedHabitDatum.habitId (always Nothing)))
+                                model.editingHistoryHabitAmount
+                    }
+            in
+            newModel
+                ! [ getHabitsAndHabitDataAndFrequencyStats
+                  , case newModel.historyViewerSelectedDate of
                         Just ymd ->
-                            update (SetHistoryViewerSelectedDate ymd) model
+                            getHistoryViewerFrequencyStats ymd
 
                         Nothing ->
-                            -- TODO: show error message because of invalid date input
-                            ( model, Cmd.none )
-                    )
+                            Cmd.none
+                  ]
 
-            SetHistoryViewerSelectedDate ymd ->
-                { model | historyViewerSelectedDate = Just ymd } ! [ getHistoryViewerFrequencyStats ymd ]
+        OnToggleHistoryViewer ->
+            ( { model | openHistoryViewer = not model.openHistoryViewer }
+            , Cmd.none
+            )
 
-            OnGetPastFrequencyStatsFailure apiError ->
-                ( { model | historyViewerFrequencyStats = RemoteData.Failure apiError }, Cmd.none )
+        OnToggleTodayViewer ->
+            ( { model | openTodayViewer = not model.openTodayViewer }, Cmd.none )
 
-            OnGetPastFrequencyStatsSuccess { frequencyStatsList } ->
-                ( { model | historyViewerFrequencyStats = RemoteData.Success frequencyStatsList }, Cmd.none )
+        OnHistoryViewerDateInput newDateInput ->
+            ( { model
+                | historyViewerDateInput =
+                    newDateInput
+                        |> String.filter
+                            (\char -> List.member char [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '/' ])
+              }
+            , Cmd.none
+            )
 
-            OnHistoryViewerChangeDate ->
-                ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
+        OnHistoryViewerSelectYesterday ->
+            let
+                yesterday =
+                    YmdDate.addDays -1 model.ymd
+            in
+            update (SetHistoryViewerSelectedDate yesterday) model
 
-            OnHistoryViewerHabitDataInput forDate habitId newInput ->
-                let
-                    editingHabitDataDict =
-                        model.editingHistoryHabitAmount
-                            |> Dict.get (YmdDate.toSimpleString forDate)
-                            ?> Dict.empty
+        OnHistoryViewerSelectBeforeYesterday ->
+            let
+                beforeYesterday =
+                    YmdDate.addDays -2 model.ymd
+            in
+            update (SetHistoryViewerSelectedDate beforeYesterday) model
 
-                    newAmount =
-                        extractInt newInput (Dict.get habitId editingHabitDataDict)
+        OnHistoryViewerSelectDateInput ->
+            let
+                ymd =
+                    YmdDate.fromSimpleString model.historyViewerDateInput
+            in
+            case ymd of
+                Just ymd ->
+                    update (SetHistoryViewerSelectedDate ymd) model
 
-                    updatedEditingHabitDataDict =
-                        editingHabitDataDict |> Dict.update habitId (always newAmount)
-                in
-                    ( { model
-                        | editingHistoryHabitAmount =
-                            model.editingHistoryHabitAmount
-                                |> Dict.update
-                                    (YmdDate.toSimpleString forDate)
-                                    (always <| Just updatedEditingHabitDataDict)
-                      }
-                    , Cmd.none
-                    )
+                Nothing ->
+                    -- TODO: show error message because of invalid date input
+                    ( model, Cmd.none )
+
+        SetHistoryViewerSelectedDate ymd ->
+            { model | historyViewerSelectedDate = Just ymd } ! [ getHistoryViewerFrequencyStats ymd ]
+
+        OnGetPastFrequencyStatsFailure apiError ->
+            ( { model | historyViewerFrequencyStats = RemoteData.Failure apiError }, Cmd.none )
+
+        OnGetPastFrequencyStatsSuccess { frequencyStatsList } ->
+            ( { model | historyViewerFrequencyStats = RemoteData.Success frequencyStatsList }, Cmd.none )
+
+        OnHistoryViewerChangeDate ->
+            ( { model | historyViewerSelectedDate = Nothing }, Cmd.none )
+
+        OnHistoryViewerHabitDataInput forDate habitId newInput ->
+            let
+                editingHabitDataDict =
+                    model.editingHistoryHabitAmount
+                        |> Dict.get (YmdDate.toSimpleString forDate)
+                        ?> Dict.empty
+
+                newAmount =
+                    extractInt newInput (Dict.get habitId editingHabitDataDict)
+
+                updatedEditingHabitDataDict =
+                    editingHabitDataDict |> Dict.update habitId (always newAmount)
+            in
+            ( { model
+                | editingHistoryHabitAmount =
+                    model.editingHistoryHabitAmount
+                        |> Dict.update
+                            (YmdDate.toSimpleString forDate)
+                            (always <| Just updatedEditingHabitDataDict)
+              }
+            , Cmd.none
+            )
 
 
 extractInt : String -> Maybe Int -> Maybe Int

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -3,6 +3,7 @@ module View exposing (..)
 import DefaultServices.Infix exposing (..)
 import DefaultServices.Util as Util
 import Dict
+import HabitUtil
 import Html exposing (Html, button, div, hr, i, input, span, text, textarea)
 import Html.Attributes exposing (class, classList, placeholder, value)
 import Html.Events exposing (onClick, onInput)
@@ -10,6 +11,7 @@ import Keyboard.Extra as KK
 import Maybe.Extra as Maybe
 import Model exposing (Model)
 import Models.ApiError as ApiError
+import Models.FrequencyStats as FrequencyStats
 import Models.Habit as Habit
 import Models.HabitData as HabitData
 import Models.YmdDate as YmdDate
@@ -25,6 +27,7 @@ view model =
             model.ymd
             model.allHabits
             model.allHabitData
+            model.allFrequencyStats
             model.addHabit
             model.editingTodayHabitAmount
             model.openTodayViewer
@@ -34,6 +37,7 @@ view model =
             model.historyViewerSelectedDate
             model.allHabits
             model.allHabitData
+            model.allFrequencyStats
             model.editingHistoryHabitAmount
         ]
 
@@ -42,243 +46,269 @@ renderTodayPanel :
     YmdDate.YmdDate
     -> RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     -> RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    -> RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     -> Habit.AddHabitInputData
     -> Dict.Dict String Int
     -> Bool
     -> Html Msg
-renderTodayPanel ymd rdHabits rdHabitData addHabit editingHabitDataDict openView =
+renderTodayPanel ymd rdHabits rdHabitData rdFrequencyStatsList addHabit editingHabitDataDict openView =
     let
         createHabitData =
             Habit.extractCreateHabit addHabit
     in
-    div
-        [ class "today-panel" ]
-        [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Todays Progress" ]
-        , dropdownIcon openView NoOp
-        , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
-        , case ( rdHabits, rdHabitData ) of
-            ( RemoteData.Success habits, RemoteData.Success habitData ) ->
-                let
-                    ( goodHabits, badHabits ) =
-                        Habit.splitHabits habits
+        div
+            [ class "today-panel" ]
+            [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Today's Progress" ]
+            , dropdownIcon openView NoOp
+            , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
+            , case ( rdHabits, rdHabitData ) of
+                ( RemoteData.Success habits, RemoteData.Success habitData ) ->
+                    let
+                        ( goodHabits, badHabits ) =
+                            Habit.splitHabits habits
 
-                    renderHabit habit =
-                        renderHabitBox ymd habitData editingHabitDataDict OnHabitDataInput SetHabitData habit
-                in
-                div [ classList [ ( "display-none", not openView ) ] ]
-                    [ div
-                        [ class "habit-list good-habits" ]
-                        (List.map renderHabit goodHabits)
-                    , div
-                        [ class "habit-list bad-habits" ]
-                        (List.map renderHabit badHabits)
+                        ( sortedGoodHabits, sortedBadHabits ) =
+                            case rdFrequencyStatsList of
+                                RemoteData.Success frequencyStatsList ->
+                                    ( HabitUtil.sortHabitsByCurrentFragment frequencyStatsList goodHabits
+                                    , HabitUtil.sortHabitsByCurrentFragment frequencyStatsList badHabits
+                                    )
+
+                                _ ->
+                                    ( goodHabits, badHabits )
+
+                        renderHabit habit =
+                            renderHabitBox
+                                (case rdFrequencyStatsList of
+                                    RemoteData.Success frequencyStatsList ->
+                                        HabitUtil.findFrequencyStatsForHabit
+                                            habit
+                                            frequencyStatsList
+
+                                    _ ->
+                                        Err "Frequency stats not available for any habits"
+                                )
+                                ymd
+                                habitData
+                                editingHabitDataDict
+                                OnHabitDataInput
+                                SetHabitData
+                                habit
+                    in
+                        div [ classList [ ( "display-none", not openView ) ] ]
+                            [ div
+                                [ class "habit-list good-habits" ]
+                                (List.map renderHabit sortedGoodHabits)
+                            , div
+                                [ class "habit-list bad-habits" ]
+                                (List.map renderHabit sortedBadHabits)
+                            , button
+                                [ class "add-habit"
+                                , onClick <|
+                                    if addHabit.openView then
+                                        OnCancelAddHabit
+                                    else
+                                        OnOpenAddHabit
+                                ]
+                                [ text <|
+                                    if addHabit.openView then
+                                        "Cancel"
+                                    else
+                                        "Add Habit"
+                                ]
+                            ]
+
+                ( RemoteData.Failure apiError, _ ) ->
+                    text "Failure..."
+
+                ( _, RemoteData.Failure apiError ) ->
+                    text "Failure..."
+
+                _ ->
+                    text "Loading..."
+            , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
+            , div
+                [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
+                [ div
+                    [ class "add-habit-input-form-habit-tag-name" ]
+                    [ button
+                        [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
+                        , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
+                        ]
+                        [ text "Good Habit" ]
                     , button
-                        [ class "add-habit"
-                        , onClick <|
-                            if addHabit.openView then
-                                OnCancelAddHabit
-                            else
-                                OnOpenAddHabit
+                        [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
+                        , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
                         ]
-                        [ text <|
-                            if addHabit.openView then
-                                "Cancel"
-                            else
-                                "Add Habit"
+                        [ text "Bad Habit" ]
+                    ]
+                , div
+                    [ class "add-habit-input-form-name-and-description" ]
+                    [ input
+                        [ class "add-habit-input-form-name"
+                        , placeholder "Name..."
+                        , onInput OnAddHabitNameInput
+                        , value addHabit.name
+                        ]
+                        []
+                    , textarea
+                        [ class "add-habit-input-form-description"
+                        , placeholder "Short description..."
+                        , onInput OnAddHabitDescriptionInput
+                        , value addHabit.description
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-time-of-day", True )
+                        , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
                         ]
                     ]
-
-            ( RemoteData.Failure apiError, _ ) ->
-                text "Failure..."
-
-            ( _, RemoteData.Failure apiError ) ->
-                text "Failure..."
-
-            _ ->
-                text "Loading..."
-        , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
-        , div
-            [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
-            [ div
-                [ class "add-habit-input-form-habit-tag-name" ]
-                [ button
-                    [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
-                    , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
-                    ]
-                    [ text "Good Habit" ]
-                , button
-                    [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
-                    , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
-                    ]
-                    [ text "Bad Habit" ]
-                ]
-            , div
-                [ class "add-habit-input-form-name-and-description" ]
-                [ input
-                    [ class "add-habit-input-form-name"
-                    , placeholder "Name..."
-                    , onInput OnAddHabitNameInput
-                    , value addHabit.name
-                    ]
-                    []
-                , textarea
-                    [ class "add-habit-input-form-description"
-                    , placeholder "Short description..."
-                    , onInput OnAddHabitDescriptionInput
-                    , value addHabit.description
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-time-of-day", True )
-                    , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
-                    ]
-                ]
-                [ button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
-                    ]
-                    [ text "ANYTIME" ]
-                , button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Morning
-                    ]
-                    [ text "MORNING" ]
-                , button
-                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
-                    , onClick <| OnSelectAddGoodHabitTime Habit.Evening
-                    ]
-                    [ text "EVENING" ]
-                ]
-            , div
-                [ class "add-habit-input-form-unit-name" ]
-                [ input
-                    [ class "habit-unit-name-singular"
-                    , placeholder "Unit name singular..."
-                    , onInput OnAddHabitUnitNameSingularInput
-                    , value addHabit.unitNameSingular
-                    ]
-                    []
-                , input
-                    [ class "habit-unit-name-plural"
-                    , placeholder "Unit name plural..."
-                    , onInput OnAddHabitUnitNamePluralInput
-                    , value addHabit.unitNamePlural
-                    ]
-                    []
-                ]
-            , div
-                [ class "add-habit-input-form-frequency-tag-name" ]
-                [ button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
-                    ]
-                    [ text "X Per Week" ]
-                , button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
-                    ]
-                    [ text "Specific Days of Week" ]
-                , button
-                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
-                    , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
-                    ]
-                    [ text "Y Per X Days" ]
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-x-times-per-week", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "X"
-                    , onInput OnAddHabitTimesPerWeekInput
-                    , value (addHabit.timesPerWeek ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-specific-days-of-week", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "Monday"
-                    , onInput OnAddHabitSpecificDayMondayInput
-                    , value (addHabit.mondayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Tuesday"
-                    , onInput OnAddHabitSpecificDayTuesdayInput
-                    , value (addHabit.tuesdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Wednesday"
-                    , onInput OnAddHabitSpecificDayWednesdayInput
-                    , value (addHabit.wednesdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Thursday"
-                    , onInput OnAddHabitSpecificDayThursdayInput
-                    , value (addHabit.thursdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Friday"
-                    , onInput OnAddHabitSpecificDayFridayInput
-                    , value (addHabit.fridayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Saturday"
-                    , onInput OnAddHabitSpecificDaySaturdayInput
-                    , value (addHabit.saturdayTimes ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Sunday"
-                    , onInput OnAddHabitSpecificDaySundayInput
-                    , value (addHabit.sundayTimes ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , div
-                [ classList
-                    [ ( "add-habit-input-form-x-times-per-y-days", True )
-                    , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
-                    ]
-                ]
-                [ input
-                    [ placeholder "Times"
-                    , onInput OnAddHabitTimesInput
-                    , value (addHabit.times ||> toString ?> "")
-                    ]
-                    []
-                , input
-                    [ placeholder "Days"
-                    , onInput OnAddHabitDaysInput
-                    , value (addHabit.days ||> toString ?> "")
-                    ]
-                    []
-                ]
-            , case createHabitData of
-                Nothing ->
-                    Util.hiddenDiv
-
-                Just createHabitData ->
-                    button
-                        [ class "add-new-habit"
-                        , onClick <| AddHabit createHabitData
+                    [ button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
                         ]
-                        [ text "Create Habit" ]
+                        [ text "ANYTIME" ]
+                    , button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Morning
+                        ]
+                        [ text "MORNING" ]
+                    , button
+                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
+                        , onClick <| OnSelectAddGoodHabitTime Habit.Evening
+                        ]
+                        [ text "EVENING" ]
+                    ]
+                , div
+                    [ class "add-habit-input-form-unit-name" ]
+                    [ input
+                        [ class "habit-unit-name-singular"
+                        , placeholder "Unit name singular..."
+                        , onInput OnAddHabitUnitNameSingularInput
+                        , value addHabit.unitNameSingular
+                        ]
+                        []
+                    , input
+                        [ class "habit-unit-name-plural"
+                        , placeholder "Unit name plural..."
+                        , onInput OnAddHabitUnitNamePluralInput
+                        , value addHabit.unitNamePlural
+                        ]
+                        []
+                    ]
+                , div
+                    [ class "add-habit-input-form-frequency-tag-name" ]
+                    [ button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
+                        ]
+                        [ text "X Per Week" ]
+                    , button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
+                        ]
+                        [ text "Specific Days of Week" ]
+                    , button
+                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
+                        , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
+                        ]
+                        [ text "Y Per X Days" ]
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-x-times-per-week", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "X"
+                        , onInput OnAddHabitTimesPerWeekInput
+                        , value (addHabit.timesPerWeek ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-specific-days-of-week", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "Monday"
+                        , onInput OnAddHabitSpecificDayMondayInput
+                        , value (addHabit.mondayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Tuesday"
+                        , onInput OnAddHabitSpecificDayTuesdayInput
+                        , value (addHabit.tuesdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Wednesday"
+                        , onInput OnAddHabitSpecificDayWednesdayInput
+                        , value (addHabit.wednesdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Thursday"
+                        , onInput OnAddHabitSpecificDayThursdayInput
+                        , value (addHabit.thursdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Friday"
+                        , onInput OnAddHabitSpecificDayFridayInput
+                        , value (addHabit.fridayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Saturday"
+                        , onInput OnAddHabitSpecificDaySaturdayInput
+                        , value (addHabit.saturdayTimes ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Sunday"
+                        , onInput OnAddHabitSpecificDaySundayInput
+                        , value (addHabit.sundayTimes ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , div
+                    [ classList
+                        [ ( "add-habit-input-form-x-times-per-y-days", True )
+                        , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
+                        ]
+                    ]
+                    [ input
+                        [ placeholder "Times"
+                        , onInput OnAddHabitTimesInput
+                        , value (addHabit.times ||> toString ?> "")
+                        ]
+                        []
+                    , input
+                        [ placeholder "Days"
+                        , onInput OnAddHabitDaysInput
+                        , value (addHabit.days ||> toString ?> "")
+                        ]
+                        []
+                    ]
+                , case createHabitData of
+                    Nothing ->
+                        Util.hiddenDiv
+
+                    Just createHabitData ->
+                        button
+                            [ class "add-new-habit"
+                            , onClick <| AddHabit createHabitData
+                            ]
+                            [ text "Create Habit" ]
+                ]
             ]
-        ]
 
 
 renderHistoryViewerPanel :
@@ -287,9 +317,10 @@ renderHistoryViewerPanel :
     -> Maybe YmdDate.YmdDate
     -> RemoteData.RemoteData ApiError.ApiError (List Habit.Habit)
     -> RemoteData.RemoteData ApiError.ApiError (List HabitData.HabitData)
+    -> RemoteData.RemoteData ApiError.ApiError (List FrequencyStats.FrequencyStats)
     -> Dict.Dict String (Dict.Dict String Int)
     -> Html Msg
-renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData editingHabitDataDictDict =
+renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData rdFrequencyStatsList editingHabitDataDictDict =
     case ( rdHabits, rdHabitData ) of
         ( RemoteData.Success habits, RemoteData.Success habitData ) ->
             div
@@ -334,6 +365,7 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData ed
 
                                 renderHabit habit =
                                     renderHabitBox
+                                        (Err "Ignore frequency stats for historical data")
                                         selectedDate
                                         habitData
                                         editingHabitDataDict
@@ -341,13 +373,13 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData ed
                                         SetHabitData
                                         habit
                             in
-                            div
-                                []
-                                [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
-                                , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
-                                , div [ class "habit-list good-habits" ] <| List.map renderHabit goodHabits
-                                , div [ class "habit-list bad-habits" ] <| List.map renderHabit badHabits
-                                ]
+                                div
+                                    []
+                                    [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
+                                    , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
+                                    , div [ class "habit-list good-habits" ] <| List.map renderHabit goodHabits
+                                    , div [ class "habit-list bad-habits" ] <| List.map renderHabit badHabits
+                                    ]
                 ]
 
         ( RemoteData.Failure apiError, _ ) ->
@@ -381,14 +413,15 @@ update the habit data.
 
 -}
 renderHabitBox :
-    YmdDate.YmdDate
+    Result String FrequencyStats.FrequencyStats
+    -> YmdDate.YmdDate
     -> List HabitData.HabitData
     -> Dict.Dict String Int
     -> (String -> String -> Msg)
     -> (YmdDate.YmdDate -> String -> Maybe Int -> Msg)
     -> Habit.Habit
     -> Html Msg
-renderHabitBox ymd habitData editingHabitDataDict onHabitDataInput setHabitData habit =
+renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput setHabitData habit =
     let
         habitRecord =
             Habit.getCommonFields habit
@@ -408,39 +441,83 @@ renderHabitBox ymd habitData editingHabitDataDict onHabitDataInput setHabitData 
         editingHabitData =
             Dict.get habitRecord.id editingHabitDataDict
     in
-    div
-        [ class "habit" ]
-        [ div [ class "habit-name" ] [ text habitRecord.name ]
-        , div
-            [ classList
-                [ ( "habit-amount-complete", True )
-                , ( "editing", Maybe.isJust <| editingHabitData )
+        div
+            [ class "habit" ]
+            [ div [ class "habit-name" ] [ text habitRecord.name ]
+            , (case habitStats of
+                Err _ ->
+                    div [ class "frequency-stats" ] [ text "N/A" ]
+
+                Ok stats ->
+                    div [ class "frequency-stats" ]
+                        [ div
+                            [ classList
+                                [ ( "current-fragment-success", HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
+                                , ( "current-fragment-failure", not <| HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
+                                , ( "frequency-statistic", True )
+                                ]
+                            ]
+                            [ text <|
+                                (toString stats.currentFragmentTotal)
+                                    ++ " out of "
+                                    ++ (toString stats.currentFragmentGoal)
+                                    ++ " "
+                                    ++ habitRecord.unitNamePlural
+                            ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <|
+                                "Days left: "
+                                    ++ (toString stats.currentFragmentDaysLeft)
+                            ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <|
+                                (toString <|
+                                    round <|
+                                        (toFloat stats.successfulFragments)
+                                            * 100
+                                            / (toFloat stats.totalFragments)
+                                )
+                                    ++ "%"
+                            ]
+                        , div
+                            [ class "frequency-statistic" ]
+                            [ text <| "Streak: " ++ (toString stats.currentFragmentStreak) ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <| "Best streak: " ++ (toString stats.bestFragmentStreak) ]
+                        , div [ class "frequency-statistic" ]
+                            [ text <| "Total done: " ++ (toString stats.totalDone) ]
+                        ]
+              )
+            , div
+                [ classList
+                    [ ( "habit-amount-complete", True )
+                    , ( "editing", Maybe.isJust <| editingHabitData )
+                    ]
                 ]
-            ]
-            [ input
-                [ placeholder <|
-                    toString habitDatum
-                        ++ " "
-                        ++ (if habitDatum == 1 then
-                                habitRecord.unitNameSingular
+                [ input
+                    [ placeholder <|
+                        toString habitDatum
+                            ++ " "
+                            ++ (if habitDatum == 1 then
+                                    habitRecord.unitNameSingular
+                                else
+                                    habitRecord.unitNamePlural
+                               )
+                    , onInput <| onHabitDataInput habitRecord.id
+                    , Util.onKeydown
+                        (\key ->
+                            if key == KK.Enter then
+                                Just <| setHabitData ymd habitRecord.id editingHabitData
                             else
-                                habitRecord.unitNamePlural
-                           )
-                , onInput <| onHabitDataInput habitRecord.id
-                , Util.onKeydown
-                    (\key ->
-                        if key == KK.Enter then
-                            Just <| setHabitData ymd habitRecord.id editingHabitData
-                        else
-                            Nothing
-                    )
-                , value (editingHabitData ||> toString ?> "")
+                                Nothing
+                        )
+                    , value (editingHabitData ||> toString ?> "")
+                    ]
+                    []
+                , i
+                    [ classList [ ( "material-icons", True ) ]
+                    , onClick <| setHabitData ymd habitRecord.id editingHabitData
+                    ]
+                    [ text "check_box" ]
                 ]
-                []
-            , i
-                [ classList [ ( "material-icons", True ) ]
-                , onClick <| setHabitData ymd habitRecord.id editingHabitData
-                ]
-                [ text "check_box" ]
             ]
-        ]

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -440,23 +440,37 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
 
         editingHabitData =
             Dict.get habitRecord.id editingHabitDataDict
+
+        isCurrentFragmentSuccessful =
+            case habitStats of
+                Err _ ->
+                    False
+
+                Ok stats ->
+                    HabitUtil.isHabitCurrentFragmentSuccessful habit stats
+
+        frequencyStatisticDiv str =
+            div
+                [ class "frequency-statistic" ]
+                [ text str ]
     in
         div
-            [ class "habit" ]
+            [ class
+                (if isCurrentFragmentSuccessful then
+                    "habit-success"
+                 else
+                    "habit-failure"
+                )
+            ]
             [ div [ class "habit-name" ] [ text habitRecord.name ]
             , (case habitStats of
                 Err _ ->
-                    div [ class "frequency-stats" ] [ text "N/A" ]
+                    frequencyStatisticDiv "N/A"
 
                 Ok stats ->
-                    div [ class "frequency-stats" ]
+                    div [ class "frequency-stats-list" ]
                         [ div
-                            [ classList
-                                [ ( "current-fragment-success", HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
-                                , ( "current-fragment-failure", not <| HabitUtil.isHabitCurrentFragmentSuccessful habit stats )
-                                , ( "frequency-statistic", True )
-                                ]
-                            ]
+                            [ class "current-progress" ]
                             [ text <|
                                 (toString stats.currentFragmentTotal)
                                     ++ " out of "
@@ -464,28 +478,19 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
                                     ++ " "
                                     ++ habitRecord.unitNamePlural
                             ]
-                        , div [ class "frequency-statistic" ]
-                            [ text <|
-                                "Days left: "
-                                    ++ (toString stats.currentFragmentDaysLeft)
-                            ]
-                        , div [ class "frequency-statistic" ]
-                            [ text <|
-                                (toString <|
-                                    round <|
-                                        (toFloat stats.successfulFragments)
-                                            * 100
-                                            / (toFloat stats.totalFragments)
-                                )
-                                    ++ "%"
-                            ]
-                        , div
-                            [ class "frequency-statistic" ]
-                            [ text <| "Streak: " ++ (toString stats.currentFragmentStreak) ]
-                        , div [ class "frequency-statistic" ]
-                            [ text <| "Best streak: " ++ (toString stats.bestFragmentStreak) ]
-                        , div [ class "frequency-statistic" ]
-                            [ text <| "Total done: " ++ (toString stats.totalDone) ]
+                        , frequencyStatisticDiv ("Days left: " ++ (toString stats.currentFragmentDaysLeft))
+                        , frequencyStatisticDiv
+                            ((toString <|
+                                round <|
+                                    (toFloat stats.successfulFragments)
+                                        * 100
+                                        / (toFloat stats.totalFragments)
+                             )
+                                ++ "%"
+                            )
+                        , frequencyStatisticDiv ("Streak: " ++ (toString stats.currentFragmentStreak))
+                        , frequencyStatisticDiv ("Best streak: " ++ (toString stats.bestFragmentStreak))
+                        , frequencyStatisticDiv ("Total done: " ++ (toString stats.totalDone))
                         ]
               )
             , div

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -56,259 +56,259 @@ renderTodayPanel ymd rdHabits rdHabitData rdFrequencyStatsList addHabit editingH
         createHabitData =
             Habit.extractCreateHabit addHabit
     in
-        div
-            [ class "today-panel" ]
-            [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Today's Progress" ]
-            , dropdownIcon openView NoOp
-            , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
-            , case ( rdHabits, rdHabitData ) of
-                ( RemoteData.Success habits, RemoteData.Success habitData ) ->
-                    let
-                        ( goodHabits, badHabits ) =
-                            Habit.splitHabits habits
+    div
+        [ class "today-panel" ]
+        [ div [ class "today-panel-title", onClick OnToggleTodayViewer ] [ text "Today's Progress" ]
+        , dropdownIcon openView NoOp
+        , div [ class "today-panel-date" ] [ text <| YmdDate.prettyPrint ymd ]
+        , case ( rdHabits, rdHabitData ) of
+            ( RemoteData.Success habits, RemoteData.Success habitData ) ->
+                let
+                    ( goodHabits, badHabits ) =
+                        Habit.splitHabits habits
 
-                        ( sortedGoodHabits, sortedBadHabits ) =
-                            case rdFrequencyStatsList of
+                    ( sortedGoodHabits, sortedBadHabits ) =
+                        case rdFrequencyStatsList of
+                            RemoteData.Success frequencyStatsList ->
+                                ( HabitUtil.sortHabitsByCurrentFragment frequencyStatsList goodHabits
+                                , HabitUtil.sortHabitsByCurrentFragment frequencyStatsList badHabits
+                                )
+
+                            _ ->
+                                ( goodHabits, badHabits )
+
+                    renderHabit habit =
+                        renderHabitBox
+                            (case rdFrequencyStatsList of
                                 RemoteData.Success frequencyStatsList ->
-                                    ( HabitUtil.sortHabitsByCurrentFragment frequencyStatsList goodHabits
-                                    , HabitUtil.sortHabitsByCurrentFragment frequencyStatsList badHabits
-                                    )
+                                    HabitUtil.findFrequencyStatsForHabit
+                                        habit
+                                        frequencyStatsList
 
                                 _ ->
-                                    ( goodHabits, badHabits )
-
-                        renderHabit habit =
-                            renderHabitBox
-                                (case rdFrequencyStatsList of
-                                    RemoteData.Success frequencyStatsList ->
-                                        HabitUtil.findFrequencyStatsForHabit
-                                            habit
-                                            frequencyStatsList
-
-                                    _ ->
-                                        Err "Frequency stats not available for any habits"
-                                )
-                                ymd
-                                habitData
-                                editingHabitDataDict
-                                OnHabitDataInput
-                                SetHabitData
-                                habit
-                    in
-                        div [ classList [ ( "display-none", not openView ) ] ]
-                            [ div
-                                [ class "habit-list good-habits" ]
-                                (List.map renderHabit sortedGoodHabits)
-                            , div
-                                [ class "habit-list bad-habits" ]
-                                (List.map renderHabit sortedBadHabits)
-                            , button
-                                [ class "add-habit"
-                                , onClick <|
-                                    if addHabit.openView then
-                                        OnCancelAddHabit
-                                    else
-                                        OnOpenAddHabit
-                                ]
-                                [ text <|
-                                    if addHabit.openView then
-                                        "Cancel"
-                                    else
-                                        "Add Habit"
-                                ]
-                            ]
-
-                ( RemoteData.Failure apiError, _ ) ->
-                    text "Failure..."
-
-                ( _, RemoteData.Failure apiError ) ->
-                    text "Failure..."
-
-                _ ->
-                    text "Loading..."
-            , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
-            , div
-                [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
-                [ div
-                    [ class "add-habit-input-form-habit-tag-name" ]
-                    [ button
-                        [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
-                        , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
-                        ]
-                        [ text "Good Habit" ]
+                                    Err "Frequency stats not available for any habits"
+                            )
+                            ymd
+                            habitData
+                            editingHabitDataDict
+                            OnHabitDataInput
+                            SetHabitData
+                            habit
+                in
+                div [ classList [ ( "display-none", not openView ) ] ]
+                    [ div
+                        [ class "habit-list good-habits" ]
+                        (List.map renderHabit sortedGoodHabits)
+                    , div
+                        [ class "habit-list bad-habits" ]
+                        (List.map renderHabit sortedBadHabits)
                     , button
-                        [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
-                        , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
+                        [ class "add-habit"
+                        , onClick <|
+                            if addHabit.openView then
+                                OnCancelAddHabit
+                            else
+                                OnOpenAddHabit
                         ]
-                        [ text "Bad Habit" ]
-                    ]
-                , div
-                    [ class "add-habit-input-form-name-and-description" ]
-                    [ input
-                        [ class "add-habit-input-form-name"
-                        , placeholder "Name..."
-                        , onInput OnAddHabitNameInput
-                        , value addHabit.name
-                        ]
-                        []
-                    , textarea
-                        [ class "add-habit-input-form-description"
-                        , placeholder "Short description..."
-                        , onInput OnAddHabitDescriptionInput
-                        , value addHabit.description
-                        ]
-                        []
-                    ]
-                , div
-                    [ classList
-                        [ ( "add-habit-input-form-time-of-day", True )
-                        , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
+                        [ text <|
+                            if addHabit.openView then
+                                "Cancel"
+                            else
+                                "Add Habit"
                         ]
                     ]
-                    [ button
-                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
-                        , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
-                        ]
-                        [ text "ANYTIME" ]
-                    , button
-                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
-                        , onClick <| OnSelectAddGoodHabitTime Habit.Morning
-                        ]
-                        [ text "MORNING" ]
-                    , button
-                        [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
-                        , onClick <| OnSelectAddGoodHabitTime Habit.Evening
-                        ]
-                        [ text "EVENING" ]
-                    ]
-                , div
-                    [ class "add-habit-input-form-unit-name" ]
-                    [ input
-                        [ class "habit-unit-name-singular"
-                        , placeholder "Unit name singular..."
-                        , onInput OnAddHabitUnitNameSingularInput
-                        , value addHabit.unitNameSingular
-                        ]
-                        []
-                    , input
-                        [ class "habit-unit-name-plural"
-                        , placeholder "Unit name plural..."
-                        , onInput OnAddHabitUnitNamePluralInput
-                        , value addHabit.unitNamePlural
-                        ]
-                        []
-                    ]
-                , div
-                    [ class "add-habit-input-form-frequency-tag-name" ]
-                    [ button
-                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
-                        , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
-                        ]
-                        [ text "X Per Week" ]
-                    , button
-                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
-                        , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
-                        ]
-                        [ text "Specific Days of Week" ]
-                    , button
-                        [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
-                        , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
-                        ]
-                        [ text "Y Per X Days" ]
-                    ]
-                , div
-                    [ classList
-                        [ ( "add-habit-input-form-x-times-per-week", True )
-                        , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
-                        ]
-                    ]
-                    [ input
-                        [ placeholder "X"
-                        , onInput OnAddHabitTimesPerWeekInput
-                        , value (addHabit.timesPerWeek ||> toString ?> "")
-                        ]
-                        []
-                    ]
-                , div
-                    [ classList
-                        [ ( "add-habit-input-form-specific-days-of-week", True )
-                        , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
-                        ]
-                    ]
-                    [ input
-                        [ placeholder "Monday"
-                        , onInput OnAddHabitSpecificDayMondayInput
-                        , value (addHabit.mondayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Tuesday"
-                        , onInput OnAddHabitSpecificDayTuesdayInput
-                        , value (addHabit.tuesdayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Wednesday"
-                        , onInput OnAddHabitSpecificDayWednesdayInput
-                        , value (addHabit.wednesdayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Thursday"
-                        , onInput OnAddHabitSpecificDayThursdayInput
-                        , value (addHabit.thursdayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Friday"
-                        , onInput OnAddHabitSpecificDayFridayInput
-                        , value (addHabit.fridayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Saturday"
-                        , onInput OnAddHabitSpecificDaySaturdayInput
-                        , value (addHabit.saturdayTimes ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Sunday"
-                        , onInput OnAddHabitSpecificDaySundayInput
-                        , value (addHabit.sundayTimes ||> toString ?> "")
-                        ]
-                        []
-                    ]
-                , div
-                    [ classList
-                        [ ( "add-habit-input-form-x-times-per-y-days", True )
-                        , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
-                        ]
-                    ]
-                    [ input
-                        [ placeholder "Times"
-                        , onInput OnAddHabitTimesInput
-                        , value (addHabit.times ||> toString ?> "")
-                        ]
-                        []
-                    , input
-                        [ placeholder "Days"
-                        , onInput OnAddHabitDaysInput
-                        , value (addHabit.days ||> toString ?> "")
-                        ]
-                        []
-                    ]
-                , case createHabitData of
-                    Nothing ->
-                        Util.hiddenDiv
 
-                    Just createHabitData ->
-                        button
-                            [ class "add-new-habit"
-                            , onClick <| AddHabit createHabitData
-                            ]
-                            [ text "Create Habit" ]
+            ( RemoteData.Failure apiError, _ ) ->
+                text "Failure..."
+
+            ( _, RemoteData.Failure apiError ) ->
+                text "Failure..."
+
+            _ ->
+                text "Loading..."
+        , hr [ classList [ ( "add-habit-line-breaker", True ), ( "visibility-hidden height-0", not addHabit.openView ) ] ] []
+        , div
+            [ classList [ ( "add-habit-input-form", True ), ( "display-none", not addHabit.openView ) ] ]
+            [ div
+                [ class "add-habit-input-form-habit-tag-name" ]
+                [ button
+                    [ classList [ ( "selected", addHabit.kind == Habit.GoodHabitKind ) ]
+                    , onClick <| OnSelectAddHabitKind Habit.GoodHabitKind
+                    ]
+                    [ text "Good Habit" ]
+                , button
+                    [ classList [ ( "selected", addHabit.kind == Habit.BadHabitKind ) ]
+                    , onClick <| OnSelectAddHabitKind Habit.BadHabitKind
+                    ]
+                    [ text "Bad Habit" ]
                 ]
+            , div
+                [ class "add-habit-input-form-name-and-description" ]
+                [ input
+                    [ class "add-habit-input-form-name"
+                    , placeholder "Name..."
+                    , onInput OnAddHabitNameInput
+                    , value addHabit.name
+                    ]
+                    []
+                , textarea
+                    [ class "add-habit-input-form-description"
+                    , placeholder "Short description..."
+                    , onInput OnAddHabitDescriptionInput
+                    , value addHabit.description
+                    ]
+                    []
+                ]
+            , div
+                [ classList
+                    [ ( "add-habit-input-form-time-of-day", True )
+                    , ( "display-none", addHabit.kind /= Habit.GoodHabitKind )
+                    ]
+                ]
+                [ button
+                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Anytime ) ]
+                    , onClick <| OnSelectAddGoodHabitTime Habit.Anytime
+                    ]
+                    [ text "ANYTIME" ]
+                , button
+                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Morning ) ]
+                    , onClick <| OnSelectAddGoodHabitTime Habit.Morning
+                    ]
+                    [ text "MORNING" ]
+                , button
+                    [ classList [ ( "habit-time-of-day", True ), ( "selected", addHabit.goodHabitTime == Habit.Evening ) ]
+                    , onClick <| OnSelectAddGoodHabitTime Habit.Evening
+                    ]
+                    [ text "EVENING" ]
+                ]
+            , div
+                [ class "add-habit-input-form-unit-name" ]
+                [ input
+                    [ class "habit-unit-name-singular"
+                    , placeholder "Unit name singular..."
+                    , onInput OnAddHabitUnitNameSingularInput
+                    , value addHabit.unitNameSingular
+                    ]
+                    []
+                , input
+                    [ class "habit-unit-name-plural"
+                    , placeholder "Unit name plural..."
+                    , onInput OnAddHabitUnitNamePluralInput
+                    , value addHabit.unitNamePlural
+                    ]
+                    []
+                ]
+            , div
+                [ class "add-habit-input-form-frequency-tag-name" ]
+                [ button
+                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.TotalWeekFrequencyKind ) ]
+                    , onClick <| OnAddHabitSelectFrequencyKind Habit.TotalWeekFrequencyKind
+                    ]
+                    [ text "X Per Week" ]
+                , button
+                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.SpecificDayOfWeekFrequencyKind ) ]
+                    , onClick <| OnAddHabitSelectFrequencyKind Habit.SpecificDayOfWeekFrequencyKind
+                    ]
+                    [ text "Specific Days of Week" ]
+                , button
+                    [ classList [ ( "selected", addHabit.frequencyKind == Habit.EveryXDayFrequencyKind ) ]
+                    , onClick <| OnAddHabitSelectFrequencyKind Habit.EveryXDayFrequencyKind
+                    ]
+                    [ text "Y Per X Days" ]
+                ]
+            , div
+                [ classList
+                    [ ( "add-habit-input-form-x-times-per-week", True )
+                    , ( "display-none", addHabit.frequencyKind /= Habit.TotalWeekFrequencyKind )
+                    ]
+                ]
+                [ input
+                    [ placeholder "X"
+                    , onInput OnAddHabitTimesPerWeekInput
+                    , value (addHabit.timesPerWeek ||> toString ?> "")
+                    ]
+                    []
+                ]
+            , div
+                [ classList
+                    [ ( "add-habit-input-form-specific-days-of-week", True )
+                    , ( "display-none", addHabit.frequencyKind /= Habit.SpecificDayOfWeekFrequencyKind )
+                    ]
+                ]
+                [ input
+                    [ placeholder "Monday"
+                    , onInput OnAddHabitSpecificDayMondayInput
+                    , value (addHabit.mondayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Tuesday"
+                    , onInput OnAddHabitSpecificDayTuesdayInput
+                    , value (addHabit.tuesdayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Wednesday"
+                    , onInput OnAddHabitSpecificDayWednesdayInput
+                    , value (addHabit.wednesdayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Thursday"
+                    , onInput OnAddHabitSpecificDayThursdayInput
+                    , value (addHabit.thursdayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Friday"
+                    , onInput OnAddHabitSpecificDayFridayInput
+                    , value (addHabit.fridayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Saturday"
+                    , onInput OnAddHabitSpecificDaySaturdayInput
+                    , value (addHabit.saturdayTimes ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Sunday"
+                    , onInput OnAddHabitSpecificDaySundayInput
+                    , value (addHabit.sundayTimes ||> toString ?> "")
+                    ]
+                    []
+                ]
+            , div
+                [ classList
+                    [ ( "add-habit-input-form-x-times-per-y-days", True )
+                    , ( "display-none", addHabit.frequencyKind /= Habit.EveryXDayFrequencyKind )
+                    ]
+                ]
+                [ input
+                    [ placeholder "Times"
+                    , onInput OnAddHabitTimesInput
+                    , value (addHabit.times ||> toString ?> "")
+                    ]
+                    []
+                , input
+                    [ placeholder "Days"
+                    , onInput OnAddHabitDaysInput
+                    , value (addHabit.days ||> toString ?> "")
+                    ]
+                    []
+                ]
+            , case createHabitData of
+                Nothing ->
+                    Util.hiddenDiv
+
+                Just createHabitData ->
+                    button
+                        [ class "add-new-habit"
+                        , onClick <| AddHabit createHabitData
+                        ]
+                        [ text "Create Habit" ]
             ]
+        ]
 
 
 renderHistoryViewerPanel :
@@ -391,13 +391,13 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData rd
                                         SetHabitData
                                         habit
                             in
-                                div
-                                    []
-                                    [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
-                                    , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
-                                    , div [ class "habit-list good-habits" ] <| List.map renderHabit sortedGoodHabits
-                                    , div [ class "habit-list bad-habits" ] <| List.map renderHabit sortedBadHabits
-                                    ]
+                            div
+                                []
+                                [ span [ class "selected-date-title" ] [ text <| YmdDate.prettyPrint selectedDate ]
+                                , span [ class "change-date", onClick OnHistoryViewerChangeDate ] [ text "change date" ]
+                                , div [ class "habit-list good-habits" ] <| List.map renderHabit sortedGoodHabits
+                                , div [ class "habit-list bad-habits" ] <| List.map renderHabit sortedBadHabits
+                                ]
                 ]
 
         ( RemoteData.Failure apiError, _ ) ->
@@ -472,75 +472,74 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
                 [ class "frequency-statistic" ]
                 [ text str ]
     in
-        div
-            [ class
-                (if isCurrentFragmentSuccessful then
-                    "habit-success"
-                 else
-                    "habit-failure"
-                )
-            ]
-            [ div [ class "habit-name" ] [ text habitRecord.name ]
-            , (case habitStats of
-                Err _ ->
-                    frequencyStatisticDiv "Error retriving performance stats"
+    div
+        [ class
+            (if isCurrentFragmentSuccessful then
+                "habit-success"
+             else
+                "habit-failure"
+            )
+        ]
+        [ div [ class "habit-name" ] [ text habitRecord.name ]
+        , case habitStats of
+            Err _ ->
+                frequencyStatisticDiv "Error retriving performance stats"
 
-                Ok stats ->
-                    div [ class "frequency-stats-list" ]
-                        [ div
-                            [ class "current-progress" ]
-                            [ text <|
-                                (toString stats.currentFragmentTotal)
-                                    ++ " out of "
-                                    ++ (toString stats.currentFragmentGoal)
-                                    ++ " "
-                                    ++ habitRecord.unitNamePlural
-                            ]
-                        , frequencyStatisticDiv ("Days left: " ++ (toString stats.currentFragmentDaysLeft))
-                        , frequencyStatisticDiv
-                            ((toString <|
-                                round <|
-                                    (toFloat stats.successfulFragments)
-                                        * 100
-                                        / (toFloat stats.totalFragments)
-                             )
-                                ++ "%"
-                            )
-                        , frequencyStatisticDiv ("Streak: " ++ (toString stats.currentFragmentStreak))
-                        , frequencyStatisticDiv ("Best streak: " ++ (toString stats.bestFragmentStreak))
-                        , frequencyStatisticDiv ("Total done: " ++ (toString stats.totalDone))
+            Ok stats ->
+                div [ class "frequency-stats-list" ]
+                    [ div
+                        [ class "current-progress" ]
+                        [ text <|
+                            toString stats.currentFragmentTotal
+                                ++ " out of "
+                                ++ toString stats.currentFragmentGoal
+                                ++ " "
+                                ++ habitRecord.unitNamePlural
                         ]
-              )
-            , div
-                [ classList
-                    [ ( "habit-amount-complete", True )
-                    , ( "editing", Maybe.isJust <| editingHabitData )
-                    ]
-                ]
-                [ input
-                    [ placeholder <|
-                        toString habitDatum
-                            ++ " "
-                            ++ (if habitDatum == 1 then
-                                    habitRecord.unitNameSingular
-                                else
-                                    habitRecord.unitNamePlural
-                               )
-                    , onInput <| onHabitDataInput habitRecord.id
-                    , Util.onKeydown
-                        (\key ->
-                            if key == KK.Enter then
-                                Just <| setHabitData ymd habitRecord.id editingHabitData
-                            else
-                                Nothing
+                    , frequencyStatisticDiv ("Days left: " ++ toString stats.currentFragmentDaysLeft)
+                    , frequencyStatisticDiv
+                        ((toString <|
+                            round <|
+                                toFloat stats.successfulFragments
+                                    * 100
+                                    / toFloat stats.totalFragments
+                         )
+                            ++ "%"
                         )
-                    , value (editingHabitData ||> toString ?> "")
+                    , frequencyStatisticDiv ("Streak: " ++ toString stats.currentFragmentStreak)
+                    , frequencyStatisticDiv ("Best streak: " ++ toString stats.bestFragmentStreak)
+                    , frequencyStatisticDiv ("Total done: " ++ toString stats.totalDone)
                     ]
-                    []
-                , i
-                    [ classList [ ( "material-icons", True ) ]
-                    , onClick <| setHabitData ymd habitRecord.id editingHabitData
-                    ]
-                    [ text "check_box" ]
+        , div
+            [ classList
+                [ ( "habit-amount-complete", True )
+                , ( "editing", Maybe.isJust <| editingHabitData )
                 ]
             ]
+            [ input
+                [ placeholder <|
+                    toString habitDatum
+                        ++ " "
+                        ++ (if habitDatum == 1 then
+                                habitRecord.unitNameSingular
+                            else
+                                habitRecord.unitNamePlural
+                           )
+                , onInput <| onHabitDataInput habitRecord.id
+                , Util.onKeydown
+                    (\key ->
+                        if key == KK.Enter then
+                            Just <| setHabitData ymd habitRecord.id editingHabitData
+                        else
+                            Nothing
+                    )
+                , value (editingHabitData ||> toString ?> "")
+                ]
+                []
+            , i
+                [ classList [ ( "material-icons", True ) ]
+                , onClick <| setHabitData ymd habitRecord.id editingHabitData
+                ]
+                [ text "check_box" ]
+            ]
+        ]

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -486,30 +486,33 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
                 frequencyStatisticDiv "Error retriving performance stats"
 
             Just stats ->
-                div [ class "frequency-stats-list" ]
-                    [ div
-                        [ class "current-progress" ]
-                        [ text <|
-                            toString stats.currentFragmentTotal
-                                ++ " out of "
-                                ++ toString stats.currentFragmentGoal
-                                ++ " "
-                                ++ habitRecord.unitNamePlural
+                if not stats.habitHasStarted then
+                    div [ class "current-progress" ] [ text "Start this habit!" ]
+                else
+                    div [ class "frequency-stats-list" ]
+                        [ div
+                            [ class "current-progress" ]
+                            [ text <|
+                                toString stats.currentFragmentTotal
+                                    ++ " out of "
+                                    ++ toString stats.currentFragmentGoal
+                                    ++ " "
+                                    ++ habitRecord.unitNamePlural
+                            ]
+                        , frequencyStatisticDiv ("Days left: " ++ toString stats.currentFragmentDaysLeft)
+                        , frequencyStatisticDiv
+                            ((toString <|
+                                round <|
+                                    toFloat stats.successfulFragments
+                                        * 100
+                                        / toFloat stats.totalFragments
+                             )
+                                ++ "%"
+                            )
+                        , frequencyStatisticDiv ("Streak: " ++ toString stats.currentFragmentStreak)
+                        , frequencyStatisticDiv ("Best streak: " ++ toString stats.bestFragmentStreak)
+                        , frequencyStatisticDiv ("Total done: " ++ toString stats.totalDone)
                         ]
-                    , frequencyStatisticDiv ("Days left: " ++ toString stats.currentFragmentDaysLeft)
-                    , frequencyStatisticDiv
-                        ((toString <|
-                            round <|
-                                toFloat stats.successfulFragments
-                                    * 100
-                                    / toFloat stats.totalFragments
-                         )
-                            ++ "%"
-                        )
-                    , frequencyStatisticDiv ("Streak: " ++ toString stats.currentFragmentStreak)
-                    , frequencyStatisticDiv ("Best streak: " ++ toString stats.bestFragmentStreak)
-                    , frequencyStatisticDiv ("Total done: " ++ toString stats.totalDone)
-                    ]
         , div
             [ classList
                 [ ( "habit-amount-complete", True )

--- a/web-client/src/View.elm
+++ b/web-client/src/View.elm
@@ -86,7 +86,7 @@ renderTodayPanel ymd rdHabits rdHabitData rdFrequencyStatsList addHabit editingH
                                         frequencyStatsList
 
                                 _ ->
-                                    Err "Frequency stats not available for any habits"
+                                    Nothing
                             )
                             ymd
                             habitData
@@ -382,7 +382,7 @@ renderHistoryViewerPanel openView dateInput selectedDate rdHabits rdHabitData rd
                                                     frequencyStatsList
 
                                             _ ->
-                                                Err "Frequency stats not available for any habits"
+                                                Nothing
                                         )
                                         selectedDate
                                         habitData
@@ -431,7 +431,7 @@ update the habit data.
 
 -}
 renderHabitBox :
-    Result String FrequencyStats.FrequencyStats
+    Maybe FrequencyStats.FrequencyStats
     -> YmdDate.YmdDate
     -> List HabitData.HabitData
     -> Dict.Dict String Int
@@ -461,10 +461,10 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
 
         isCurrentFragmentSuccessful =
             case habitStats of
-                Err _ ->
+                Nothing ->
                     False
 
-                Ok stats ->
+                Just stats ->
                     HabitUtil.isHabitCurrentFragmentSuccessful habit stats
 
         frequencyStatisticDiv str =
@@ -482,10 +482,10 @@ renderHabitBox habitStats ymd habitData editingHabitDataDict onHabitDataInput se
         ]
         [ div [ class "habit-name" ] [ text habitRecord.name ]
         , case habitStats of
-            Err _ ->
+            Nothing ->
                 frequencyStatisticDiv "Error retriving performance stats"
 
-            Ok stats ->
+            Just stats ->
                 div [ class "frequency-stats-list" ]
                     [ div
                         [ class "current-progress" ]


### PR DESCRIPTION
  - Create GraphQL query get_frequency_stats that returns performance statistics for the requested habits (default: all habits)
  - Show frequency stats on page
  - Automatically update frequency stats when new habt data is entered
  - Sort habits by completion of current fragment goal, and by days left in current fragment

Along the way a couple dev tools used:
  - Added proto-repl to project.clj as a dependency
  - Imported clojure.tools.namespace.repl/refresh for easier refreshing of namespaces while developing
  - Imported clojure.test/run-tests so you can always run tests from user namespace
  - Added documentation about refreshing within lein repl